### PR TITLE
Collapsible Sidebar

### DIFF
--- a/frontend/src/components/icons/AppIcons.ts
+++ b/frontend/src/components/icons/AppIcons.ts
@@ -83,6 +83,10 @@ import {
   AlignJustify,
   ArrowLeft,
   ArrowRight,
+  PanelRightClose,
+  PanelLeftOpen,
+  PanelRightOpen,
+  PanelLeftClose,
 } from 'lucide-react';
 
 export const AppIcons = {
@@ -96,6 +100,10 @@ export const AppIcons = {
   help: HelpCircle,
   logout: LogOut,
   loading: Loader2,
+  panelRightClose: PanelRightClose,
+  panelRightOpen: PanelRightOpen,
+  panelLeftClose: PanelLeftClose,
+  panelLeftOpen: PanelLeftOpen,
 
   // User / Auth
   user: User,

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -5,17 +5,25 @@ import Sidebar from './Sidebar';
 
 export default function AppLayout() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false); // ← Add this
 
   return (
-    <div className="w-full min-h-screen flex overflow-x-hidden bg-primary">
-      <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+    <div className="w-full min-h-screen flex overflow-x-hidden">
+      <Sidebar
+        sidebarOpen={sidebarOpen}
+        setSidebarOpen={setSidebarOpen}
+        mobileSidebarOpen={mobileSidebarOpen}
+        setMobileSidebarOpen={setMobileSidebarOpen}
+      />
 
-      {/* Right side */}
-      <div className="flex-1 flex flex-col lg:pl-64">
-        <Topbar onMenuClick={() => setSidebarOpen(true)} />
+      <div
+        className={`flex-1 flex flex-col transition-all duration-300 ${
+          sidebarOpen ? 'lg:pl-72' : 'lg:pl-16'
+        }`}
+      >
+        <Topbar onMenuClick={() => setMobileSidebarOpen(true)} />
 
-        {/* Main content wrapper with rounded top-left */}
-        <div className="flex-1 bg-base-100 lg:rounded-tl-3xl shadow-md overflow-hidden border-l border-base-300">
+        <div className="flex-1 bg-base-100 overflow-hidden">
           <main>
             <Outlet />
           </main>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, Link } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
@@ -8,8 +7,8 @@ import { useSidebarNav  } from '../../constants/SidebarNav';
 import BudgenixLogo from '../../assets/Logo/BudgenixLogo.png';
 import { Dialog, DialogBackdrop, DialogPanel, TransitionChild } from '@headlessui/react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
-import { useUser } from '@/context/UserContext';
 import type {  SidebarSection } from '@/types/shared/sidebar';
+import { AppIcons } from '../icons/AppIcons';
 
 
 function classNames(...classes: (string | undefined | null | false)[]) {
@@ -19,27 +18,30 @@ function classNames(...classes: (string | undefined | null | false)[]) {
 export default function Sidebar({
   sidebarOpen,
   setSidebarOpen,
+  mobileSidebarOpen,
+  setMobileSidebarOpen
 }: {
   sidebarOpen: boolean;
+  mobileSidebarOpen: boolean;
   setSidebarOpen: (open: boolean) => void;
+  setMobileSidebarOpen: (open: boolean) => void;
 }) {
   const { t } = useTranslation();
   const { logout } = useAuth();
   const { pathname } = useLocation();
-  const { user, cachedUser } = useUser();
 
   const isActive = (path?: string) => pathname === path;
 
   return (
     <>
       {/* Mobile Sidebar */}
-      <Dialog open={sidebarOpen} onClose={setSidebarOpen} className="relative z-50 lg:hidden">
-        <DialogBackdrop className="fixed inset-0 bg-base-200 transition-opacity" />
+      <Dialog open={mobileSidebarOpen} onClose={setMobileSidebarOpen} className="relative z-50 lg:hidden">
+        <DialogBackdrop className="fixed inset-0 bg-base-300/50 backdrop-blur-xs transition-opacity" />
         <div className="fixed inset-0 flex">
-          <DialogPanel className="relative flex w-full max-w-xs flex-1 transform bg-primary p-4 ring-1 ring-primary-content/10 transition duration-300 ease-in-out">
+          <DialogPanel className="relative flex w-full max-w-xs flex-1 transform bg-base-200 text-base-content p-4 ring-1 ring-base-300 transition duration-300 ease-in-out">
             <TransitionChild>
               <div className="absolute top-0 left-full flex w-16 justify-center pt-5">
-                <button type="button" onClick={() => setSidebarOpen(false)} className="-m-2.5 p-2.5">
+                <button type="button" onClick={() => setMobileSidebarOpen(false)} className="-m-2.5 p-2.5">
                   <span className="sr-only">Close sidebar</span>
                   <XMarkIcon aria-hidden="true" className="size-6 text-base-content" />
                 </button>
@@ -50,8 +52,15 @@ export default function Sidebar({
               <div className="flex h-16 items-center">
                 <img src={BudgenixLogo} alt="Budgenix" className="h-8 w-auto" />
               </div>
+
               <nav className="flex-1 flex flex-col gap-4">
-                <SidebarContent t={t} logout={logout} isActive={isActive} setSidebarOpen={setSidebarOpen} />
+                <SidebarContent
+                  t={t}
+                  logout={logout}
+                  isActive={isActive}
+                  setMobileSidebarOpen={setMobileSidebarOpen}
+                  sidebarOpen={true}
+                />
               </nav>
             </div>
           </DialogPanel>
@@ -59,66 +68,79 @@ export default function Sidebar({
       </Dialog>
 
       {/* Desktop Sidebar */}
-      <aside className="hidden lg:flex lg:flex-col lg:w-64 lg:fixed lg:inset-y-0 bg-base-200 text-base-content px-4 py-6 text-sm font-medium">
-        <SidebarProfile user={user} cachedUser={cachedUser} />
+      <aside
+        className={classNames(
+          "hidden lg:flex lg:flex-col lg:fixed lg:inset-y-0 transition-all duration-300 border-r border-base-300 bg-base-200 text-base-content text-sm font-medium",
+          sidebarOpen ? "lg:w-72 px-2 py-2" : "lg:w-16 px-2 py-2"
+        )}
+      >
+      <div className="relative group flex items-center justify-between h-12 w-full px-2">
+        {sidebarOpen ? (
+          <>
+            {/* Full Sidebar: Logo + Hide Button */}
+            <Link to="/dashboard" className="flex items-center gap-2">
+              <img src={BudgenixLogo} alt="Budgenix" className="h-6 w-auto" />
+            </Link>
+            <button
+              onClick={() => setSidebarOpen(false)}
+              className="text-base-content/60 hover:text-base-content"
+            >
+              <AppIcons.panelLeftClose className="w-5 h-5" />
+            </button>
+          </>
+        ) : (
+          <>
+          <div className="relative group w-full flex justify-center items-center">
+            {/* Toggle button: only shows on hover */}
+            <button
+              type="button"
+              onClick={() => setSidebarOpen(true)}
+              className="absolute inset-0 z-10 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
+              aria-label="Open sidebar"
+            >
+              <AppIcons.panelLeftOpen className="w-5 h-5 text-base-content" />
+            </button>
+
+            {/* Logo: shown by default, hides on hover */}
+            <Link
+              to="/dashboard"
+              className="transition-opacity group-hover:opacity-0 z-0"
+            >
+              <img src={BudgenixLogo} alt="Budgenix" className="h-6 w-auto" />
+            </Link>
+          </div>
+
+          </>
+        )}
+      </div>
+
+
+
         <nav className="flex-1 flex flex-col gap-8 pt-4 overflow-y-auto">
-          <SidebarContent t={t} logout={logout} isActive={isActive} />
+          <SidebarContent
+            t={t}
+            logout={logout}
+            isActive={isActive}
+            sidebarOpen={sidebarOpen}
+          />
+
         </nav>
       </aside>
     </>
   );
 }
 
-const SidebarProfile = React.memo(function SidebarProfile({
-  user,
-  cachedUser
-}: {
-  user: ReturnType<typeof useUser>['user'];
-  cachedUser: ReturnType<typeof useUser>['cachedUser'];
-}) {
-  const getInitials = (first: string, last: string) =>
-    `${first?.[0] ?? ''}${last?.[0] ?? ''}`.toUpperCase();
-
-  const displayUser = user ?? cachedUser;
-
-  if (!displayUser) {
-    return (
-      <div className="flex items-center gap-3 mb-2">
-        <div className="w-10 h-10 rounded-full bg-primary-content/20 flex items-center justify-center font-bold text-sm uppercase">
-          –
-        </div>
-        <div className="leading-tight">
-          <div className="font-medium">Loading...</div>
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex items-center gap-3 mb-2">
-      <div className="w-10 h-10 rounded-full bg-primary-content/20 flex items-center justify-center font-bold text-sm uppercase">
-        {getInitials(displayUser.firstName, displayUser.lastName)}
-      </div>
-      <div className="leading-tight">
-        <div className="font-medium">
-          {`${displayUser.firstName} ${displayUser.lastName}`}
-        </div>
-        <div className="text-xs text-base-content/70 truncate">
-          {displayUser.email}
-        </div>
-      </div>
-    </div>
-  );
-});
-
 type SidebarContentProps = {
   t: (key: string) => string;
   logout: () => void;
   isActive: (path?: string) => boolean;
   setSidebarOpen?: (open: boolean) => void;
+  sidebarOpen?: boolean;
+  setMobileSidebarOpen?: (open: boolean) => void;
 };
 
-function SidebarContent({ t, logout, isActive, setSidebarOpen }: SidebarContentProps) {
+
+function SidebarContent({ t, logout, isActive, setSidebarOpen, sidebarOpen, setMobileSidebarOpen }: SidebarContentProps) {
   const navigate = useNavigate();
   const sidebarNav = useSidebarNav();
 
@@ -132,9 +154,11 @@ function SidebarContent({ t, logout, isActive, setSidebarOpen }: SidebarContentP
     <>
       {sidebarNav.map((section: SidebarSection) => (
         <div key={section.section} className="space-y-1">
-          <p className="text-xs font-semibold uppercase tracking-wide mb-1 px-1">
-            {t(section.section)}
-          </p>
+          {sidebarOpen && (
+            <p className="text-xs font-semibold uppercase tracking-wide mb-1 px-1">
+              {t(section.section)}
+            </p>
+          )}
           <ul className="space-y-1">
             {section.items.map((item) => {
               if ('action' in item && item.action === 'logout') {
@@ -144,7 +168,7 @@ function SidebarContent({ t, logout, isActive, setSidebarOpen }: SidebarContentP
                       onClick={handleLogout}
                       className="flex items-center w-full gap-2 px-2 py-2 rounded-md transition hover:bg-base-300 hover:text-base-content cursor-pointer">
                       <item.icon className="w-4 h-4 shrink-0" />
-                      {t(item.label)}
+                        {sidebarOpen && <span>{t(item.label)}</span>}
                     </button>
                   </li>
                 );
@@ -155,17 +179,22 @@ function SidebarContent({ t, logout, isActive, setSidebarOpen }: SidebarContentP
                   <li key={item.label}>
                     <Link
                       to={item.path}
-                      onClick={() => setSidebarOpen?.(false)}
+                      onClick={() => {
+                        setSidebarOpen?.(false);
+                        setMobileSidebarOpen?.(false);
+                      }}
+                      
                       className={classNames(
                         'flex items-center gap-2 px-2 py-2 rounded-md transition-colors',
                         isActive(item.path)
-                          ? 'bg-base-300 border-l-4 border-primary text-base-content'
+                          ? 'bg-base-300 text-base-content'
                           : 'text-base-content/80 hover:bg-base-300 hover:text-base-content'
                       )}
                     >
-                      <item.icon className="w-4 h-4 shrink-0" />
-                      {t(item.label)}
+                      <item.icon className="w-5 h-5 shrink-0" />
+                      {sidebarOpen && <span>{t(item.label)}</span>}
                     </Link>
+
                   </li>
                 );
               }

--- a/frontend/src/components/layout/Topbar.tsx
+++ b/frontend/src/components/layout/Topbar.tsx
@@ -9,7 +9,7 @@ export default function Topbar({ onMenuClick }: { onMenuClick?: () => void }) {
   const { selectedMonth, setSelectedMonth, selectedYear, setSelectedYear } = useDateFilter();
 
   return (
-    <div className="bg-base-200 text-base-content z-30 w-full">
+    <div className="bg-base-100 border-b border-base-200 text-base-content z-30 w-full">
       <div className="h-16 flex items-center justify-between px-4 sm:px-6 w-full max-w-full">
         {/* Left: hamburger always visible on mobile */}
         <div className="flex items-center gap-2 flex-1 min-w-0">


### PR DESCRIPTION
### ✨ Collapsible Sidebar

- The sidebar is now **collapsible on desktop**:
  - When collapsed, it shows **icons only** with no section headers or labels
  - Hovering over the logo reveals a button to **reopen the sidebar**
  - When open, it displays the full layout with **labels and section titles**

- On **mobile**, the sidebar now:
  - Opens as an **overlay** on top of the current page (e.g. Dashboard stays visible in the background)
  - Uses consistent theming and layout with the desktop version
  - Can be toggled open/closed using a dedicated close button

This improves navigation clarity and gives users more screen space when needed.
