### PR TITLE
fix: use correct user currency field and sync dropdown on reload

### DIFF
--- a/backend/Budgenix.API/Controllers/StripeController.cs
+++ b/backend/Budgenix.API/Controllers/StripeController.cs
@@ -249,12 +249,12 @@ namespace Budgenix.API.Controllers
 
             if (!string.IsNullOrEmpty(session.Currency))
             {
-                user.PreferredCurrency = session.Currency.ToUpper();
+                user.Currency = session.Currency.ToUpper();
             }
 
             await _context.SaveChangesAsync();
 
-            Console.WriteLine($"User {user.Email} updated: active subscription, customerId {customerId}, billingCycle {user.BillingCycle}, currency {user.PreferredCurrency}");
+            Console.WriteLine($"User {user.Email} updated: active subscription, customerId {customerId}, billingCycle {user.BillingCycle}, currency {user.Currency}");
         }
 
 

--- a/backend/Budgenix.API/Dtos/Admin/AdminUserDto.cs
+++ b/backend/Budgenix.API/Dtos/Admin/AdminUserDto.cs
@@ -19,7 +19,7 @@ namespace Budgenix.Dtos.Admin
         public BillingCycleEnum? BillingCycle { get; set; }
         public DateTime? SubscriptionStartDate { get; set; }
         public DateTime? SubscriptionEndDate { get; set; }
-        public string? PreferredCurrency { get; set; }
+        public string? Currency { get; set; }
         public string? ReferralCode { get; set; }
         public string? Country { get; set; }
     }

--- a/backend/Budgenix.API/Dtos/Users/UserDto.cs
+++ b/backend/Budgenix.API/Dtos/Users/UserDto.cs
@@ -21,7 +21,7 @@ namespace Budgenix.Dtos.Users
         public DateTime? SubscriptionEndDate { get; set; }
         public BillingCycleEnum BillingCycle { get; set; }
         public string? ReferralCode { get; set; }
-        public string PreferredCurrency { get; set; } = "USD";
+        public string Currency { get; set; } = "USD";
         public bool IsAdmin { get; set; }
     }
 }

--- a/backend/Budgenix.API/Migrations/20250719164552_RenamePreferredCurrencyToCurrency.Designer.cs
+++ b/backend/Budgenix.API/Migrations/20250719164552_RenamePreferredCurrencyToCurrency.Designer.cs
@@ -4,6 +4,7 @@ using Budgenix.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Budgenix.API.Migrations
 {
     [DbContext(typeof(BudgenixDbContext))]
-    partial class BudgenixDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250719164552_RenamePreferredCurrencyToCurrency")]
+    partial class RenamePreferredCurrencyToCurrency
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Budgenix.API/Migrations/20250719164552_RenamePreferredCurrencyToCurrency.cs
+++ b/backend/Budgenix.API/Migrations/20250719164552_RenamePreferredCurrencyToCurrency.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Budgenix.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class RenamePreferredCurrencyToCurrency : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "PreferredCurrency",
+                table: "AspNetUsers",
+                newName: "Currency");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "Currency",
+                table: "AspNetUsers",
+                newName: "PreferredCurrency");
+        }
+    }
+}

--- a/backend/Budgenix.API/Models/Users/ApplicationUser.cs
+++ b/backend/Budgenix.API/Models/Users/ApplicationUser.cs
@@ -82,7 +82,7 @@ namespace Budgenix.Models.Users
         public DateTime? DiscountEndDate { get; set; }
 
         //Financial
-        public string PreferredCurrency { get; set; } = "USD"; // Default fallback
+        public string Currency { get; set; } = "USD"; // Default fallback
 
         //Admin related tracking
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;

--- a/backend/Budgenix.API/Services/Admin/AdminService.cs
+++ b/backend/Budgenix.API/Services/Admin/AdminService.cs
@@ -84,7 +84,7 @@ namespace Budgenix.Services.Admin
                 BillingCycle = user.BillingCycle,
                 SubscriptionStartDate = user.SubscriptionStartDate,
                 SubscriptionEndDate = user.SubscriptionEndDate,
-                PreferredCurrency = user.PreferredCurrency,
+                Currency = user.Currency,
                 ReferralCode = user.ReferralCode,
                 Role = roles.FirstOrDefault() ?? "User",
                 Stats = new UserStatsDto

--- a/backend/Budgenix.API/Services/Insights/Rules/LowIncomeCoverageRule.cs
+++ b/backend/Budgenix.API/Services/Insights/Rules/LowIncomeCoverageRule.cs
@@ -31,7 +31,7 @@ namespace Budgenix.Services.Insights.Rules
                 .SumAsync(r => (decimal?)r.Amount) ?? 0;
 
             var user = await _userService.GetCurrentUserAsync();
-            var currency = user?.PreferredCurrency ?? "USD";
+            var currency = user?.Currency ?? "USD";
 
             if (income < upcomingRecurring)
             {

--- a/backend/Budgenix.API/Services/User/UserService.cs
+++ b/backend/Budgenix.API/Services/User/UserService.cs
@@ -65,7 +65,7 @@ namespace Budgenix.Services.User
                 SubscriptionEndDate = user.SubscriptionEndDate,
                 BillingCycle = user.BillingCycle,
                 ReferralCode = user.ReferralCode,
-                PreferredCurrency = user.PreferredCurrency ?? "USD",
+                Currency = user.Currency ?? "USD",
                 IsAdmin = isAdmin
             };
         }
@@ -105,7 +105,7 @@ namespace Budgenix.Services.User
         public async Task<string> GetCurrencyAsync()
         {
             var user = await GetCurrentUserAsync();
-            return user?.PreferredCurrency ?? "USD";
+            return user?.Currency ?? "USD";
         }
 
         public async Task UpdateCurrencyAsync(string currency)
@@ -113,7 +113,7 @@ namespace Budgenix.Services.User
             var user = await GetCurrentUserAsync();
             if (user == null) throw new UnauthorizedAccessException();
 
-            user.PreferredCurrency = currency;
+            user.Currency = currency;
             await _userManager.UpdateAsync(user);
         }
     }

--- a/frontend/src/components/common/CurrencyDropdown.tsx
+++ b/frontend/src/components/common/CurrencyDropdown.tsx
@@ -15,7 +15,7 @@ export default function CurrencyDropdown() {
   const [open, setOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  const current = currencies.find(c => c.code === currency);
+  const current = currencies.find(c => c.code === currency);  
 
   const handleSelect = async (code: string) => {
     setOpen(false);

--- a/frontend/src/context/CurrencyContext.tsx
+++ b/frontend/src/context/CurrencyContext.tsx
@@ -13,39 +13,53 @@ const CurrencyContext = createContext<CurrencyContextType>({
 });
 
 export function CurrencyProvider({ children }: { children: React.ReactNode }) {
-  const { user } = useUser();
+  const { user, cachedUser, isLoading } = useUser();
   const queryClient = useQueryClient();
-  const [currency, setLocalCurrency] = useState<string | undefined>(user?.currency);
 
+  const [currency, setLocalCurrency] = useState<string | undefined>(
+    user?.currency || cachedUser?.currency
+  );
+  
   useEffect(() => {
-    if (user?.currency !== currency) {
-      setLocalCurrency(user?.currency);
+    console.log('[CurrencyProvider] useEffect: user?.currency =', user?.currency);
+    if (user?.currency && user.currency !== currency) {
+      console.log('[CurrencyProvider] Setting localCurrency from user.currency');
+      setLocalCurrency(user.currency);
     }
   }, [user?.currency]);
 
-const { mutate: updateCurrency } = useMutation({
-  mutationFn: async (newCurrency: string) => {
-    return apiFetch('/api/user/me/currency', {
-      method: 'PUT',
-      body: JSON.stringify({ currency: newCurrency }),
-    });
-  },
-  onSuccess: async () => {
-    await queryClient.invalidateQueries({ queryKey: ['user'] });
-    await queryClient.refetchQueries({ queryKey: ['user'] });
-  },
-  onError: (err) => {
-    console.error('[CurrencyProvider] Currency change failed:', err);
-  },
-});
 
+  const { mutateAsync: updateCurrency } = useMutation({
+    mutationFn: async (newCurrency: string) => {
+      return apiFetch('/api/user/me/currency', {
+        method: 'PUT',
+        body: JSON.stringify({ currency: newCurrency }),
+      });
+    },
+    onSuccess: async (_, newCurrency) => {
+      setLocalCurrency(newCurrency);
+      await queryClient.invalidateQueries({ queryKey: ['user'] });
+    },
+    onError: (err) => {
+      console.error('[CurrencyProvider] Currency change failed:', err);
+    },
+  });
+
+  const handleSetCurrency = (newCurrency: string) => {
+    updateCurrency(newCurrency);
+  };
+
+ 
+  if (!currency && isLoading) return null;
 
   return (
-    <CurrencyContext.Provider value={{ currency, setCurrency: updateCurrency }}>
+    <CurrencyContext.Provider value={{ currency, setCurrency: handleSetCurrency }}>
       {children}
     </CurrencyContext.Provider>
   );
 }
+
+
 
 export const useCurrency = () => useContext(CurrencyContext);
 

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -545,7 +545,8 @@
             "Monthly": "Monthly",
             "Quarterly": "Quarterly",
             "Yearly": "Yearly"
-        }
+        },
+        "comingSoon": "Coming Soon..."
     },
     "admin": {
         "panel": {


### PR DESCRIPTION
## ✅ Summary

This PR fixes an issue where the currency dropdown did not correctly reflect the user's selected currency after a page reload.

---

## 🔧 Changes

- Renamed backend field from `preferredCurrency` to `currency` across:
  - User entity
  - User DTOs
  - API endpoint `/api/user/me`
  - PUT endpoint `/api/user/me/currency`
- Updated frontend `User` type and logic to use `currency`
- Adjusted `CurrencyProvider` to initialize and sync state from `user.currency`
- Ensured the dropdown reflects the correct currency after a page reload using cached or live user data
