### PR TITLE
Dashboard Summary Invalidation

### DIFF
--- a/backend/Budgenix.API/Budgenix.API.csproj
+++ b/backend/Budgenix.API/Budgenix.API.csproj
@@ -27,7 +27,6 @@
   <ItemGroup>
     <Folder Include="Migrations\" />
     <Folder Include="Constants\" />
-    <Folder Include="Services\Shared\" />
   </ItemGroup>
 
 </Project>

--- a/backend/Budgenix.API/Configuration Files/Program.cs
+++ b/backend/Budgenix.API/Configuration Files/Program.cs
@@ -25,6 +25,7 @@ using Budgenix.Services.Audit;
 using Budgenix.Services.User;
 using Budgenix.Services.System;
 using Budgenix.Services.Email;
+using Budgenix.Services.Shared;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -70,6 +71,7 @@ builder.Services.AddScoped<IAdminService, AdminService>();
 builder.Services.AddScoped<IAuditService, AuditService>();
 builder.Services.AddScoped<ISystemNotificationsService, SystemNotificationsService>();
 
+builder.Services.AddSingleton<ICacheInvalidatorService, CacheInvalidatorService>();
 
 
 builder.Services.AddInsightRules();

--- a/backend/Budgenix.API/Dtos/Dashboard/DashboardDto.cs
+++ b/backend/Budgenix.API/Dtos/Dashboard/DashboardDto.cs
@@ -27,6 +27,10 @@
         public decimal SavingsGoalProgressPercent { get; set; }
         public string? NextGoalName { get; set; }
         public string? NextGoalDueDate { get; set; }
+        public decimal MonthlyCashflowBalance { get; set; }
+        public decimal MonthlyCashflowIncome { get; set; }
+        public decimal MonthlyCashflowExpenses { get; set; }
+
         public string LastUpdated { get; set; } = DateTime.UtcNow.ToString("o");
         public int AlertsCount { get; set; }
     }

--- a/backend/Budgenix.API/Services/Budgets/BudgetService.cs
+++ b/backend/Budgenix.API/Services/Budgets/BudgetService.cs
@@ -6,6 +6,7 @@ using Budgenix.Helpers.Query;
 using Budgenix.Models.Audit;
 using Budgenix.Models.Finance;
 using Budgenix.Services.Audit;
+using Budgenix.Services.Shared;
 using Microsoft.EntityFrameworkCore;
 using System.Text.Json;
 
@@ -16,12 +17,14 @@ namespace Budgenix.Services.Budgets
         private readonly BudgenixDbContext _context;
         private readonly IMapper _mapper;
         private readonly IAuditService _audit;
+        private readonly ICacheInvalidatorService _cacheInvalidatorService;
 
-        public BudgetService(BudgenixDbContext context, IMapper mapper, IAuditService audit)
+        public BudgetService(BudgenixDbContext context, IMapper mapper, IAuditService audit, ICacheInvalidatorService cacheInvalidatorService)
         {
             _context = context;
             _mapper = mapper;
             _audit = audit;
+            _cacheInvalidatorService = cacheInvalidatorService;
         }
 
         public async Task<IEnumerable<BudgetDto>> GetBudgetsAsync(string userId, string? category, BudgetTypeEnum? type, string sort, int skip, int take)
@@ -125,8 +128,10 @@ namespace Budgenix.Services.Budgets
 
             _context.Budgets.Add(budget);
             await _context.SaveChangesAsync();
-
             await _audit.LogAsync(userId, AuditActionEnum.CreateBudget, "Budget", budget.Id.ToString(), null, JsonSerializer.Serialize(budget));
+
+            _cacheInvalidatorService.InvalidateBudgets(userId);
+            _cacheInvalidatorService.InvalidateDashboard(userId, DateTime.UtcNow);
 
             return _mapper.Map<BudgetDto>(budget);
         }
@@ -157,11 +162,11 @@ namespace Budgenix.Services.Budgets
 
             _mapper.Map(dto, budget);
             budget.Category = category;
-
             await _context.SaveChangesAsync();
-
             await _audit.LogAsync(userId, AuditActionEnum.UpdateBudget, "Budget", budget.Id.ToString(), oldValues, JsonSerializer.Serialize(budget));
 
+            _cacheInvalidatorService.InvalidateBudgets(userId);
+            _cacheInvalidatorService.InvalidateDashboard(userId, DateTime.UtcNow);
             return _mapper.Map<BudgetDto>(budget);
         }
 
@@ -174,8 +179,10 @@ namespace Budgenix.Services.Budgets
 
             _context.Budgets.Remove(budget);
             await _context.SaveChangesAsync();
-
             await _audit.LogAsync(userId, AuditActionEnum.DeleteBudget, "Budget", id.ToString(), oldValues, null);
+
+            _cacheInvalidatorService.InvalidateBudgets(userId);
+            _cacheInvalidatorService.InvalidateDashboard(userId, DateTime.UtcNow);
 
             return true;
         }

--- a/backend/Budgenix.API/Services/Cashflow/CashflowService.cs
+++ b/backend/Budgenix.API/Services/Cashflow/CashflowService.cs
@@ -8,6 +8,7 @@ using Budgenix.Models.Categories;
 using Budgenix.Models.Finance;
 using Budgenix.Models.Shared;
 using Budgenix.Services.Audit;
+using Budgenix.Services.Shared;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
@@ -22,19 +23,22 @@ namespace Budgenix.Services.Finance
         private readonly IMemoryCache _cache;
         private readonly IAuditService _audit;
         private readonly IMapper _mapper;
+        private readonly ICacheInvalidatorService _cacheInvalidatorService;
 
         public CashflowService(
             BudgenixDbContext context,
             ILogger<CashflowService> logger,
             IMemoryCache cache,
             IAuditService audit,
-            IMapper mapper)
+            IMapper mapper,
+            ICacheInvalidatorService cacheInvalidatorService)
         {
             _context = context;
             _logger = logger;
             _cache = cache;
             _audit = audit;
             _mapper = mapper;
+            _cacheInvalidatorService = cacheInvalidatorService;
         }
 
         public async Task<List<CashflowItemDto>> GetItemsAsync(string userId)
@@ -55,6 +59,14 @@ namespace Budgenix.Services.Finance
 
         public async Task<CashflowSummaryDto> GetSummaryAsync(string userId)
         {
+            var cacheKey = $"cashflow:{userId}";
+
+            if (_cache.TryGetValue(cacheKey, out CashflowSummaryDto cached))
+            {
+                _logger.LogInformation("Serving cached cashflow summary for user {UserId}", userId);
+                return cached;
+            }
+
             var items = await _context.CashflowItems
                 .Include(i => i.Category)
                 .Where(i => i.UserId == userId)
@@ -89,7 +101,7 @@ namespace Budgenix.Services.Finance
             var monthlySavings = Monthly(savingsItems);
             var monthlyBalance = monthlyIncome - monthlyExpenses;
 
-            return new CashflowSummaryDto
+            var summary = new CashflowSummaryDto
             {
                 MonthlyIncome = monthlyIncome,
                 MonthlyExpenses = monthlyExpenses,
@@ -104,6 +116,9 @@ namespace Budgenix.Services.Finance
                 CategoryBreakdown = categoryBreakdown
             };
 
+            _cache.Set(cacheKey, summary, TimeSpan.FromMinutes(5));
+
+            return summary;
         }
 
         public async Task<List<InsightDto>> GetInsightsAsync(string userId)
@@ -126,7 +141,8 @@ namespace Budgenix.Services.Finance
 
             foreach (var group in categoryGroups)
             {
-                if (group.Total > 500)
+                
+                if (group.Category != "Rent" && group.Total > 500)
                 {
                     insights.Add(new InsightDto
                     {
@@ -184,6 +200,10 @@ namespace Budgenix.Services.Finance
 
             var dtoResult = _mapper.Map<CashflowItemDto>(entity);
             dtoResult.Amount = NormalizeMonthly(entity.Amount, entity.Frequency);
+
+            _cacheInvalidatorService.InvalidateCashflow(userId);
+            _cacheInvalidatorService.InvalidateDashboard(userId, DateTime.UtcNow);
+
             return dtoResult;
         }
 
@@ -218,6 +238,9 @@ namespace Budgenix.Services.Finance
                 NewValues = JsonSerializer.Serialize(entity)
             });
 
+            _cacheInvalidatorService.InvalidateCashflow(userId);
+            _cacheInvalidatorService.InvalidateDashboard(userId, DateTime.UtcNow);
+
             return true;
         }
 
@@ -243,6 +266,9 @@ namespace Budgenix.Services.Finance
                 EntityId = entity.Id.ToString(),
                 OldValues = oldValues
             });
+
+            _cacheInvalidatorService.InvalidateCashflow(userId);
+            _cacheInvalidatorService.InvalidateDashboard(userId, DateTime.UtcNow);
 
             return true;
         }

--- a/backend/Budgenix.API/Services/Dashboard/DashboardService.cs
+++ b/backend/Budgenix.API/Services/Dashboard/DashboardService.cs
@@ -12,6 +12,7 @@ public class DashboardService : IDashboardService
     private readonly BudgenixDbContext _context;
     private readonly IExpenseService _expenseService;
     private readonly IIncomeService _incomeService;
+    private readonly ICashflowService _cashflowService;
     private readonly IMemoryCache _cache;
     private readonly ILogger<DashboardService> _logger;
 
@@ -20,13 +21,15 @@ public class DashboardService : IDashboardService
         IExpenseService expenseService,
         IIncomeService incomeService,
         IMemoryCache cache,
-        ILogger<DashboardService> logger)
+        ILogger<DashboardService> logger,
+        ICashflowService cashflowService)
     {
         _context = context;
         _expenseService = expenseService;
         _incomeService = incomeService;
         _cache = cache;
         _logger = logger;
+        _cashflowService = cashflowService;
     }
 
     public async Task<DashboardSummaryDto> GetDashboardSummaryAsync(string userId, int month, int year)
@@ -76,6 +79,9 @@ public class DashboardService : IDashboardService
             .OrderBy(g => g.TargetDate)
             .FirstOrDefault();
 
+        var cashflowSummary = await _cashflowService.GetSummaryAsync(userId);
+
+
         var summary = new DashboardSummaryDto
         {
             TotalSpentThisMonth = expenseOverview.TotalExpense,
@@ -101,6 +107,9 @@ public class DashboardService : IDashboardService
             GoalsNearCompletion = goals.Count(g => g.TargetAmount > 0 && g.CurrentAmount / g.TargetAmount >= 0.9m),
             NextGoalName = nextGoal?.Name,
             NextGoalDueDate = nextGoal?.TargetDate?.ToString("o"),
+            MonthlyCashflowBalance = cashflowSummary.MonthlyBalance,
+            MonthlyCashflowIncome = cashflowSummary.MonthlyIncome,
+            MonthlyCashflowExpenses = cashflowSummary.MonthlyExpenses,
             LastUpdated = DateTime.UtcNow.ToString("o")
         };
 

--- a/backend/Budgenix.API/Services/Finance/ExpenseService.cs
+++ b/backend/Budgenix.API/Services/Finance/ExpenseService.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Budgenix.Models.Audit;
 using Budgenix.Services.Audit;
 using System.Text.Json;
+using Budgenix.Services.Shared;
 
 namespace Budgenix.Services.Finance
 {
@@ -20,19 +21,21 @@ namespace Budgenix.Services.Finance
         private readonly RecurringItemService _recurringService;
         private readonly IMemoryCache _cache;
         private readonly IAuditService _audit;
-
+        private readonly ICacheInvalidatorService _cacheInvalidatorService;
         public ExpenseService(
             BudgenixDbContext context,
             ILogger<ExpenseService> logger,
             RecurringItemService recurringService,
             IMemoryCache cache,
-            IAuditService audit)
+            IAuditService audit,
+            ICacheInvalidatorService cacheInvalidatorService)
         {
             _context = context;
             _logger = logger;
             _recurringService = recurringService;
             _cache = cache;
             _audit = audit;
+            _cacheInvalidatorService = cacheInvalidatorService;
         }
 
         public async Task<List<ExpenseDto>> GetExpensesAsync(
@@ -162,6 +165,8 @@ namespace Budgenix.Services.Finance
                 .Where(e => e.Date.Year == year && e.Date.Month == month)
                 .Sum(e => e.Amount);
 
+            _logger.LogInformation("total amount: {totalExpense}", totalExpense);
+
             var lastMonthExpense = expenses
                 .Where(e => e.Date.Year == lastMonth.Year && e.Date.Month == lastMonth.Month)
                 .Sum(e => e.Amount);
@@ -231,7 +236,8 @@ namespace Budgenix.Services.Finance
                 NewValues = JsonSerializer.Serialize(e)
             });
 
-            InvalidateExpenseOverviewCache(userId, e.Date);
+            _cacheInvalidatorService.InvalidateExpenseOverview(userId, e.Date);
+            _cacheInvalidatorService.InvalidateDashboard(userId, e.Date);
 
             return new ExpenseDto
             {
@@ -273,8 +279,9 @@ namespace Budgenix.Services.Finance
                 NewValues = JsonSerializer.Serialize(e)
             });
 
-            InvalidateExpenseOverviewCache(userId, oldDate);
-            InvalidateExpenseOverviewCache(userId, e.Date);
+            _cacheInvalidatorService.InvalidateExpenseOverview(userId, oldDate);
+            _cacheInvalidatorService.InvalidateExpenseOverview(userId, e.Date);
+            _cacheInvalidatorService.InvalidateDashboard(userId, e.Date);
 
             return true;
         }
@@ -306,21 +313,11 @@ namespace Budgenix.Services.Finance
                 OldValues = oldValues
             });
 
-            InvalidateExpenseOverviewCache(userId, e.Date);
+            _cacheInvalidatorService.InvalidateExpenseOverview(userId, e.Date);
+            _cacheInvalidatorService.InvalidateDashboard(userId, e.Date);
 
             return true;
         }
 
-        private void InvalidateExpenseOverviewCache(string userId, DateTime date)
-        {
-            var currentKey = $"expense-overview:{userId}:{date.Month}:{date.Year}";
-            var lastMonthDate = date.AddMonths(-1);
-            var lastMonthKey = $"expense-overview:{userId}:{lastMonthDate.Month}:{lastMonthDate.Year}";
-
-            _cache.Remove(currentKey);
-            _cache.Remove(lastMonthKey);
-
-            _logger.LogInformation("Invalidated cache for {0} and {1}", currentKey, lastMonthKey);
-        }
     }
 }

--- a/backend/Budgenix.API/Services/Finance/IncomeService.cs
+++ b/backend/Budgenix.API/Services/Finance/IncomeService.cs
@@ -6,6 +6,7 @@ using Budgenix.Models.Finance;
 using Budgenix.Models.Shared;
 using Budgenix.Services.Audit;
 using Budgenix.Services.Recurring;
+using Budgenix.Services.Shared;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
@@ -20,19 +21,21 @@ namespace Budgenix.Services.Finance
         private readonly RecurringItemService _recurringService;
         private readonly IMemoryCache _cache;
         private readonly IAuditService _audit;
+        private readonly ICacheInvalidatorService _cacheInvalidatorService;
 
         public IncomeService(
             BudgenixDbContext context,
             ILogger<IncomeService> logger,
             RecurringItemService recurringService,
             IMemoryCache cache,
-            IAuditService audit)
+            IAuditService audit, ICacheInvalidatorService cacheInvalidatorService)
         {
             _context = context;
             _logger = logger;
             _recurringService = recurringService;
             _cache = cache;
             _audit = audit;
+            _cacheInvalidatorService = cacheInvalidatorService;
         }
 
         public async Task<List<IncomeDto>> GetIncomesAsync(
@@ -260,7 +263,8 @@ namespace Budgenix.Services.Finance
 
             await _audit.LogAsync(userId, AuditActionEnum.CreateIncome, "Income", i.Id.ToString(), null, JsonSerializer.Serialize(i));
 
-            InvalidateIncomeOverviewCache(userId, i.Date);
+            _cacheInvalidatorService.InvalidateIncomeOverview(userId, i.Date);
+            _cacheInvalidatorService.InvalidateDashboard(userId, i.Date);
 
             return new IncomeDto
             {
@@ -296,7 +300,8 @@ namespace Budgenix.Services.Finance
 
             await _audit.LogAsync(userId, AuditActionEnum.UpdateIncome, "Income", i.Id.ToString(), oldValues, JsonSerializer.Serialize(i));
 
-            InvalidateIncomeOverviewCache(userId, i.Date);
+            _cacheInvalidatorService.InvalidateIncomeOverview(userId, i.Date);
+            _cacheInvalidatorService.InvalidateDashboard(userId, i.Date);
 
             return true;
         }
@@ -315,17 +320,10 @@ namespace Budgenix.Services.Finance
 
             await _audit.LogAsync(userId, AuditActionEnum.DeleteIncome, "Income", i.Id.ToString(), oldValues, null);
 
-            InvalidateIncomeOverviewCache(userId, i.Date);
+            _cacheInvalidatorService.InvalidateIncomeOverview(userId, i.Date);
+            _cacheInvalidatorService.InvalidateDashboard(userId, i.Date);
 
             return true;
-        }
-
-
-        private void InvalidateIncomeOverviewCache(string userId, DateTime date)
-        {
-            var key = $"income-overview:{userId}:{date.Month}:{date.Year}";
-            _cache.Remove(key);
-            _logger.LogInformation("Invalidated cache: {CacheKey}", key);
         }
     }
 }

--- a/backend/Budgenix.API/Services/Goals/GoalService.cs
+++ b/backend/Budgenix.API/Services/Goals/GoalService.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Budgenix.Services.Audit;
 using Budgenix.Models.Audit;
 using System.Text.Json;
+using Budgenix.Services.Shared;
 
 namespace Budgenix.Services.Goals
 {
@@ -15,13 +16,15 @@ namespace Budgenix.Services.Goals
         private readonly IMemoryCache _cache;
         private readonly ILogger<GoalService> _logger;
         private readonly IAuditService _audit;
+        private readonly ICacheInvalidatorService _cacheInvalidatorService;
 
-        public GoalService(BudgenixDbContext context, IMemoryCache cache, ILogger<GoalService> logger, IAuditService audit)
+        public GoalService(BudgenixDbContext context, IMemoryCache cache, ILogger<GoalService> logger, IAuditService audit, ICacheInvalidatorService cacheInvalidatorService)
         {
             _context = context;
             _cache = cache;
             _logger = logger;
             _audit = audit;
+            _cacheInvalidatorService = cacheInvalidatorService;
         }
 
         public async Task<IEnumerable<GoalDto>> GetAllGoalsAsync(string userId)
@@ -74,6 +77,8 @@ namespace Budgenix.Services.Goals
 
         public async Task<GoalDto> CreateGoalAsync(string userId, CreateGoalDto dto)
         {
+            _logger.LogInformation("Creating goal for user {UserId}", userId);
+
             var goal = new Goal
             {
                 Id = Guid.NewGuid(),
@@ -91,41 +96,32 @@ namespace Budgenix.Services.Goals
             _context.Goals.Add(goal);
             await _context.SaveChangesAsync();
 
-            await _audit.LogAsync(
-                userId: userId,
-                action: AuditActionEnum.CreateGoal,
-                entityType: "Goal",
-                entityId: goal.Id.ToString(),
-                newValues: JsonSerializer.Serialize(new
-                {
-                    goal.Name,
-                    goal.TargetAmount,
-                    goal.CurrentAmount,
-                    goal.TargetDate
-                })
-            );
+            await _audit.LogAsync(new AuditLog
+            {
+                UserId = userId,
+                Action = AuditActionEnum.CreateGoal,
+                EntityType = "Goal",
+                EntityId = goal.Id.ToString(),
+                NewValues = JsonSerializer.Serialize(goal)
+            });
 
-            InvalidateUserCache(userId);
+            _cacheInvalidatorService.InvalidateGoals(userId, goal.Id);
+            _cacheInvalidatorService.InvalidateDashboard(userId, DateTime.UtcNow);
+
             return ToDto(goal);
         }
 
         public async Task<GoalDto?> UpdateGoalAsync(string userId, Guid goalId, UpdateGoalDto dto)
         {
+            _logger.LogInformation("Updating goal {GoalId} for user {UserId}", goalId, userId);
+
             var goal = await _context.Goals
                 .Where(g => g.UserId == userId && g.Id == goalId)
                 .FirstOrDefaultAsync();
 
             if (goal == null) return null;
 
-            var oldData = new
-            {
-                goal.Name,
-                goal.Description,
-                goal.TargetAmount,
-                goal.CurrentAmount,
-                goal.TargetDate,
-                goal.Icon
-            };
+            var oldData = JsonSerializer.Serialize(goal);
 
             goal.Name = dto.Name;
             goal.Description = dto.Description;
@@ -136,58 +132,56 @@ namespace Budgenix.Services.Goals
 
             await _context.SaveChangesAsync();
 
-            await _audit.LogAsync(
-                userId: userId,
-                action: AuditActionEnum.UpdateGoal,
-                entityType: "Goal",
-                entityId: goal.Id.ToString(),
-                oldValues: JsonSerializer.Serialize(oldData),
-                newValues: JsonSerializer.Serialize(new
-                {
-                    goal.Name,
-                    goal.Description,
-                    goal.TargetAmount,
-                    goal.CurrentAmount,
-                    goal.TargetDate,
-                    goal.Icon
-                })
-            );
+            await _audit.LogAsync(new AuditLog
+            {
+                UserId = userId,
+                Action = AuditActionEnum.UpdateGoal,
+                EntityType = "Goal",
+                EntityId = goal.Id.ToString(),
+                OldValues = oldData,
+                NewValues = JsonSerializer.Serialize(goal)
+            });
 
-            InvalidateUserCache(userId, goalId);
+            _cacheInvalidatorService.InvalidateGoals(userId, goal.Id);
+            _cacheInvalidatorService.InvalidateDashboard(userId, DateTime.UtcNow);
+
             return ToDto(goal);
         }
 
         public async Task<bool> DeleteGoalAsync(string userId, Guid goalId)
         {
+            _logger.LogInformation("Deleting goal {GoalId} for user {UserId}", goalId, userId);
+
             var goal = await _context.Goals
                 .Where(g => g.UserId == userId && g.Id == goalId)
                 .FirstOrDefaultAsync();
 
             if (goal == null) return false;
 
+            var oldData = JsonSerializer.Serialize(goal);
+
             _context.Goals.Remove(goal);
             await _context.SaveChangesAsync();
 
-            await _audit.LogAsync(
-                userId: userId,
-                action: AuditActionEnum.DeleteGoal,
-                entityType: "Goal",
-                entityId: goal.Id.ToString(),
-                oldValues: JsonSerializer.Serialize(new
-                {
-                    goal.Name,
-                    goal.TargetAmount,
-                    goal.CurrentAmount,
-                    goal.TargetDate
-                })
-            );
+            await _audit.LogAsync(new AuditLog
+            {
+                UserId = userId,
+                Action = AuditActionEnum.DeleteGoal,
+                EntityType = "Goal",
+                EntityId = goal.Id.ToString(),
+                OldValues = oldData
+            });
 
-            InvalidateUserCache(userId, goalId);
+            _cacheInvalidatorService.InvalidateGoals(userId, goal.Id);
+            _cacheInvalidatorService.InvalidateDashboard(userId, DateTime.UtcNow);
+
             return true;
         }
 
         public async Task<GoalDto?> ContributeToGoalAsync(string userId, Guid goalId, GoalContributionDto dto)
         {
+            _logger.LogInformation("Contributing to goal {GoalId} for user {UserId}", goalId, userId);
+
             var goal = await _context.Goals
                 .Where(g => g.UserId == userId && g.Id == goalId)
                 .FirstOrDefaultAsync();
@@ -199,30 +193,24 @@ namespace Budgenix.Services.Goals
 
             await _context.SaveChangesAsync();
 
-            await _audit.LogAsync(
-                userId: userId,
-                action: AuditActionEnum.UpdateGoal,
-                entityType: "GoalContribution",
-                entityId: goal.Id.ToString(),
-                metadata: JsonSerializer.Serialize(new
+            await _audit.LogAsync(new AuditLog
+            {
+                UserId = userId,
+                Action = AuditActionEnum.UpdateGoal,
+                EntityType = "GoalContribution",
+                EntityId = goal.Id.ToString(),
+                Metadata = JsonSerializer.Serialize(new
                 {
                     AmountAdded = dto.Amount,
                     PreviousAmount = previousAmount,
                     NewAmount = goal.CurrentAmount
                 })
-            );
+            });
 
-            InvalidateUserCache(userId, goalId);
+            _cacheInvalidatorService.InvalidateGoals(userId, goalId);
+            _cacheInvalidatorService.InvalidateDashboard(userId, DateTime.UtcNow);
+
             return ToDto(goal);
-        }
-
-        private void InvalidateUserCache(string userId, Guid? goalId = null)
-        {
-            _cache.Remove($"goals:{userId}");
-            if (goalId != null)
-            {
-                _cache.Remove($"goal:{userId}:{goalId}");
-            }
         }
 
         private static GoalDto ToDto(Goal g) => new GoalDto

--- a/backend/Budgenix.API/Services/Shared/CacheInvalidatorService.cs
+++ b/backend/Budgenix.API/Services/Shared/CacheInvalidatorService.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.Extensions.Caching.Memory;
+
+namespace Budgenix.Services.Shared
+{
+    public class CacheInvalidatorService : ICacheInvalidatorService
+    {
+        private readonly IMemoryCache _cache;
+        private readonly ILogger<CacheInvalidatorService> _logger;
+
+        public CacheInvalidatorService(IMemoryCache cache, ILogger<CacheInvalidatorService> logger)
+        {
+            _cache = cache;
+            _logger = logger;
+        }
+
+        public void InvalidateDashboard(string userId, DateTime date)
+        {
+            var thisMonth = $"dashboard:{userId}:{date.Month}:{date.Year}";
+            var lastMonth = $"dashboard:{userId}:{date.AddMonths(-1).Month}:{date.AddMonths(-1).Year}";
+            _cache.Remove(thisMonth);
+            _cache.Remove(lastMonth);
+            _logger.LogInformation("Invalidated dashboard: {0}, {1}", thisMonth, lastMonth);
+        }
+
+        public void InvalidateExpenseOverview(string userId, DateTime date)
+        {
+            var thisMonth = $"expense-overview:{userId}:{date.Month}:{date.Year}";
+            var lastMonth = $"expense-overview:{userId}:{date.AddMonths(-1).Month}:{date.AddMonths(-1).Year}";
+            _cache.Remove(thisMonth);
+            _cache.Remove(lastMonth);
+            _logger.LogInformation("Invalidated expense overview: {0}, {1}", thisMonth, lastMonth);
+        }
+
+        public void InvalidateIncomeOverview(string userId, DateTime date)
+        {
+            var thisMonth = $"income-overview:{userId}:{date.Month}:{date.Year}";
+            var lastMonth = $"income-overview:{userId}:{date.AddMonths(-1).Month}:{date.AddMonths(-1).Year}";
+            _cache.Remove(thisMonth);
+            _cache.Remove(lastMonth);
+            _logger.LogInformation("Invalidated income overview: {0}, {1}", thisMonth, lastMonth);
+        }
+
+        public void InvalidateBudgets(string userId)
+        {
+            var key = $"budgets:{userId}";
+            _cache.Remove(key);
+            _logger.LogInformation("Invalidated budgets cache: {0}", key);
+        }
+
+        public void InvalidateGoals(string userId, Guid? goalId = null)
+        {
+            _cache.Remove($"goals:{userId}");
+            if (goalId != null)
+                _cache.Remove($"goal:{userId}:{goalId}");
+        }
+
+        public void InvalidateCashflow(string userId)
+        {
+            _cache.Remove($"cashflow:{userId}");
+        }
+
+    }
+
+}

--- a/backend/Budgenix.API/Services/Shared/ICacheInvalidatorService.cs
+++ b/backend/Budgenix.API/Services/Shared/ICacheInvalidatorService.cs
@@ -1,0 +1,12 @@
+﻿namespace Budgenix.Services.Shared
+{
+    public interface ICacheInvalidatorService
+    {
+        void InvalidateDashboard(string userId, DateTime date);
+        void InvalidateExpenseOverview(string userId, DateTime date);
+        void InvalidateIncomeOverview(string userId, DateTime date);
+        void InvalidateBudgets(string userId);
+        void InvalidateGoals(string userId, Guid? goalId = null);
+        void InvalidateCashflow(string userId);
+    }
+}

--- a/frontend/src/features/Incomes/components/IncomesList.tsx
+++ b/frontend/src/features/Incomes/components/IncomesList.tsx
@@ -19,7 +19,7 @@ export default function IncomesList({ incomes }: { incomes: Income[] }) {
   const { mutate: deleteIncome } = useDeleteIncome();
   const { mutate: updateIncome } = useUpdateIncome();
 
-  const [deletePendingId, setDeletePendingId] = useState<string | null>(null);
+  const [deletePendingIncome, setDeletePendingIncome] = useState<{ id: string; date: string } | null>(null);
   const [editItem, setEditItem] = useState<Income | null>(null);
   const [editForm, setEditForm] = useState<Partial<Income>>({});
 
@@ -28,22 +28,23 @@ export default function IncomesList({ incomes }: { incomes: Income[] }) {
     setEditForm(item);
   };
 
-  const confirmDelete = (id: string) => {
-    setDeletePendingId(id);
+  const confirmDelete = (item: Income) => {
+    setDeletePendingIncome({ id: item.id, date: item.date });
   };
 
   const handleDeleteConfirmed = () => {
-    if (deletePendingId) {
-      deleteIncome(deletePendingId, {
-        onSuccess: () => toast.success(t('incomes.toast.deleteSuccess')),
-        onError: () => toast.error(t('incomes.toast.deleteError')),
-      });
-      setDeletePendingId(null);
-    }
+    if (!deletePendingIncome) return;
+
+    deleteIncome(deletePendingIncome, {
+      onSuccess: () => toast.success(t('incomes.toast.deleteSuccess')),
+      onError: () => toast.error(t('incomes.toast.deleteError')),
+    });
+
+    setDeletePendingIncome(null);
   };
 
   const handleDeleteCancelled = () => {
-    setDeletePendingId(null);
+    setDeletePendingIncome(null);
   };
 
   const handleEditChange = (
@@ -96,7 +97,7 @@ export default function IncomesList({ incomes }: { incomes: Income[] }) {
     );
   };
 
-    const sortedIncomes = [...incomes].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  const sortedIncomes = [...incomes].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
   const paddedIncomes = [...sortedIncomes];
   while (paddedIncomes.length < minRows) {
     paddedIncomes.push({
@@ -163,12 +164,12 @@ export default function IncomesList({ incomes }: { incomes: Income[] }) {
         ]}
         actionHandlers={{
           onEdit: openEditModal,
-          onDelete: (row) => confirmDelete(row.id),
+          onDelete: confirmDelete,
         }}
       />
 
       {/* Delete Dialog */}
-      <Dialog open={!!deletePendingId} onClose={handleDeleteCancelled} className="fixed z-50 inset-0 flex items-center justify-center">
+      <Dialog open={!!deletePendingIncome} onClose={handleDeleteCancelled} className="fixed z-50 inset-0 flex items-center justify-center">
         <div className="fixed inset-0 bg-black opacity-30" />
         <div className="relative bg-base-100 rounded-lg p-6 shadow-lg">
           <Dialog.Title className="text-lg font-semibold">{t('shared.confirmDelete')}</Dialog.Title>

--- a/frontend/src/features/Incomes/services/incomesService.tsx
+++ b/frontend/src/features/Incomes/services/incomesService.tsx
@@ -66,13 +66,20 @@ async function updateIncomeApi({
 }: {
   id: string;
   data: UpdateIncomeDto;
-}): Promise<void> {
-  await apiFetch<void>(`${API_BASE_URL}/${id}`, {
+}): Promise<Income> {
+  const result = await apiFetch<Income>(`${API_BASE_URL}/${id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   });
+
+   if (!result) {
+    throw new Error('Failed to update income');
+  }
+
+  return result;
 }
+
 
 async function deleteIncomeApi(id: string): Promise<void> {
   await apiFetch<void>(`${API_BASE_URL}/${id}`, {
@@ -111,10 +118,21 @@ export function useCreateIncome() {
 
   return useMutation({
     mutationFn: createIncomeApi,
-    onSuccess: () => {
+    onSuccess: (createdIncome) => {
+
+      const date = new Date(createdIncome.date);
+      const month = date.getMonth() + 1;      
+      const year = date.getFullYear();
+
+      const lastMonth = month === 1 ? 12 : month - 1;
+      const lastMonthYear = month === 1 ? year - 1 : year;
+
+
       queryClient.invalidateQueries({ queryKey: ['incomes'] });
-      queryClient.invalidateQueries({ queryKey: ['incomeOverview'] });
-      queryClient.invalidateQueries({ queryKey: ['incomeMonthlySummary'], exact: false });
+      queryClient.invalidateQueries({ queryKey: ['incomeOverview', month, year] });
+      queryClient.invalidateQueries({ queryKey: ['incomeMonthlySummary', month, year]});
+      queryClient.invalidateQueries({ queryKey: ['incomeMonthlySummary', lastMonth, lastMonthYear]});
+      queryClient.invalidateQueries({ queryKey: ['dashboardSummary', month, year]})
     },
   });
 }
@@ -124,10 +142,19 @@ export function useUpdateIncome() {
 
   return useMutation({
     mutationFn: (payload: { id: string; data: UpdateIncomeDto }) => updateIncomeApi(payload),
-    onSuccess: () => {
+    onSuccess: (updateIncome) => {
+        const date = new Date(updateIncome.date);
+        const month = date.getMonth() + 1;
+        const year = date.getFullYear();
+
+        const lastMonth = month === 1 ? 12 : month - 1;
+        const lastMonthYear = month === 1 ? year - 1 : year;
+
       queryClient.invalidateQueries({ queryKey: ['incomes'] });
-      queryClient.invalidateQueries({ queryKey: ['incomeOverview'] });
-      queryClient.invalidateQueries({ queryKey: ['incomeMonthlySummary'], exact: false });
+      queryClient.invalidateQueries({ queryKey: ['incomeOverview', month, year] });
+      queryClient.invalidateQueries({ queryKey: ['incomeMonthlySummary', month, year]});
+      queryClient.invalidateQueries({ queryKey: ['incomeMonthlySummary', lastMonth, lastMonthYear]});
+      queryClient.invalidateQueries({ queryKey: ['dashboardSummary', month, year]})
     },
   });
 }
@@ -136,14 +163,27 @@ export function useDeleteIncome() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: deleteIncomeApi,
-    onSuccess: () => {
+    mutationFn: async ({ id, date }: { id: string; date: string }) => {
+      await deleteIncomeApi(id);
+      return date;
+    },
+    onSuccess: (deletedDate) => {
+      const date = new Date(deletedDate);
+      const month = date.getMonth() + 1;
+      const year = date.getFullYear();
+
+      const lastMonth = month === 1 ? 12 : month - 1;
+      const lastMonthYear = month === 1 ? year - 1 : year;
+
       queryClient.invalidateQueries({ queryKey: ['incomes'] });
-      queryClient.invalidateQueries({ queryKey: ['incomeOverview'] });
-      queryClient.invalidateQueries({ queryKey: ['incomeMonthlySummary'], exact: false });
+      queryClient.invalidateQueries({ queryKey: ['incomeOverview', month, year] });
+      queryClient.invalidateQueries({ queryKey: ['incomeMonthlySummary', month, year] });
+      queryClient.invalidateQueries({ queryKey: ['incomeMonthlySummary', lastMonth, lastMonthYear] });
+      queryClient.invalidateQueries({ queryKey: ['dashboardSummary', month, year] });
     },
   });
 }
+
 
 // === UTILITY ===
 export function isGroupedIncomes(data: Income[] | GroupedIncomes): data is GroupedIncomes {

--- a/frontend/src/features/budgets/services/budgetsService.ts
+++ b/frontend/src/features/budgets/services/budgetsService.ts
@@ -94,30 +94,50 @@ export function useBudgetProgress(id: string, periodStart: string, periodEnd: st
 
 export function useCreateBudget() {
   const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: createBudget,
     onSuccess: () => {
+      const now = new Date();
+      const month = now.getMonth() + 1;
+      const year = now.getFullYear();
+
       queryClient.invalidateQueries({ queryKey: ['budgets'] });
+      queryClient.invalidateQueries({ queryKey: ['dashboardSummary', month, year] });
     },
   });
 }
 
+
 export function useUpdateBudget() {
   const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: updateBudget,
     onSuccess: () => {
+      const now = new Date();
+      const month = now.getMonth() + 1;
+      const year = now.getFullYear();
+
       queryClient.invalidateQueries({ queryKey: ['budgets'] });
+      queryClient.invalidateQueries({ queryKey: ['dashboardSummary', month, year] });
     },
   });
 }
 
 export function useDeleteBudget() {
   const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: deleteBudget,
     onSuccess: () => {
+      const now = new Date();
+      const month = now.getMonth() + 1;
+      const year = now.getFullYear();
+
       queryClient.invalidateQueries({ queryKey: ['budgets'] });
+      queryClient.invalidateQueries({ queryKey: ['dashboardSummary', month, year] });
     },
   });
 }
+

--- a/frontend/src/features/dashboard/components/DashboardCard.tsx
+++ b/frontend/src/features/dashboard/components/DashboardCard.tsx
@@ -10,11 +10,13 @@ type Props = {
   value: number;
   prefix?: string;
   suffix?: string;
-  showCurrency?: boolean;
+  showCurrency?: boolean;  
+  subtext?: string;
   to?: string;
   icon: React.ReactNode;
   bg: string;
   border: string;
+  showProgress: boolean;
   progress?: number;
   emptyMessage?: string;
   animate?: boolean;
@@ -30,9 +32,11 @@ export default function DashboardCard({
   icon,
   bg,
   border,
+  showProgress,
   progress = 100,
   emptyMessage,
   animate = true,
+  subtext, // NEW
 }: Props) {
   const { currency } = useCurrency();
   const { t } = useTranslation();
@@ -72,10 +76,18 @@ export default function DashboardCard({
         border
       )}
     >
-      <div className="flex items-center gap-4 mb-3">
+    <div className="flex items-start justify-between mb-3">
+      <div className="flex items-center gap-3">
         <div className="p-2 bg-white/80 rounded-full">{icon}</div>
         <h3 className="text-xl font-semibold text-base-content">{title}</h3>
       </div>
+      {subtext && (
+        <div className="text-sm text-base-content/60 mt-1 text-right">
+          {subtext}
+        </div>
+      )}
+    </div>
+
 
       <div className="text-3xl font-bold mb-1">
         {value === 0 && emptyMessage ? (
@@ -88,15 +100,17 @@ export default function DashboardCard({
           </>
         )}
       </div>
+        {showProgress && (      
+          <div className="w-full h-2 mt-3 bg-white/20 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-white/80 transition-all duration-700"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        )}
 
-      <div className="w-full h-2 mt-3 bg-white/20 rounded-full overflow-hidden">
-        <div
-          className="h-full bg-white/80 transition-all duration-700"
-          style={{ width: `${progress}%` }}
-        />
-      </div>
 
-      <div className="text-sm text-base-content mt-2 group-hover:text-white/90 transition">
+      <div className="text-sm text-base-content mt-1 group-hover:text-white/90 transition">
         {t('dashboard.tapToView')}
       </div>
     </div>

--- a/frontend/src/features/expenses/components/ExpensesList.tsx
+++ b/frontend/src/features/expenses/components/ExpensesList.tsx
@@ -24,7 +24,7 @@ export default function ExpensesList({ expenses }: { expenses: Expense[] }) {
 
   const minRows = 15;
 
-  const [deletePendingId, setDeletePendingId] = useState<string | null>(null);
+  const [deletePendingExpense, setDeletePendingExpense] = useState<{ id: string; date: string } | null>(null);
   const [editItem, setEditItem] = useState<Expense | null>(null);
   const [editForm, setEditForm] = useState<Partial<Expense>>({});
 
@@ -33,17 +33,17 @@ export default function ExpensesList({ expenses }: { expenses: Expense[] }) {
     setEditForm(item);
   };
 
-  const confirmDelete = (id: string) => {
-    setDeletePendingId(id);
+  const confirmDelete = (expense: Expense) => {
+    setDeletePendingExpense({ id: expense.id, date: expense.date });
   };
 
   const handleDeleteConfirmed = () => {
-    if (!deletePendingId) return;
-    deleteExpense(deletePendingId, {
+    if (!deletePendingExpense) return;
+    deleteExpense(deletePendingExpense, {
       onSuccess: () => toast.success(t('expenses.toast.deleteSuccess')),
       onError: () => toast.error(t('expenses.toast.deleteError')),
     });
-    setDeletePendingId(null);
+    setDeletePendingExpense(null);
   };
 
   const handleEditChange = (
@@ -148,18 +148,18 @@ export default function ExpensesList({ expenses }: { expenses: Expense[] }) {
         ]}
         actionHandlers={{
           onEdit: openEditModal,
-          onDelete: (row) => confirmDelete(row.id),
+          onDelete: (row) => confirmDelete(row),
         }}
       />
 
       {/* Delete confirmation dialog */}
-      <Dialog open={!!deletePendingId} onClose={() => setDeletePendingId(null)} className="fixed z-50 inset-0 flex items-center justify-center">
+      <Dialog open={!!deletePendingExpense} onClose={() => setDeletePendingExpense(null)} className="fixed z-50 inset-0 flex items-center justify-center">
         <div className="fixed inset-0 bg-black opacity-30" />
         <div className="relative bg-base-100 rounded-lg p-6 shadow-lg">
           <Dialog.Title className="text-lg font-semibold">{t('shared.confirmDelete')}</Dialog.Title>
           <Dialog.Description className="mt-2">{t('expenses.confirmDeleteText')}</Dialog.Description>
           <div className="mt-4 flex justify-end gap-2">
-            <button onClick={() => setDeletePendingId(null)} className="btn btn-ghost">{t('shared.cancel')}</button>
+            <button onClick={() => setDeletePendingExpense(null)} className="btn btn-ghost">{t('shared.cancel')}</button>
             <button onClick={handleDeleteConfirmed} className="btn btn-error">{t('shared.delete')}</button>
           </div>
         </div>

--- a/frontend/src/features/expenses/components/GroupedExpensesList.tsx
+++ b/frontend/src/features/expenses/components/GroupedExpensesList.tsx
@@ -1,15 +1,19 @@
+'use client';
+
 import { useState } from 'react';
-import { formatCurrency, formatDate, truncateText } from '@/utils/formatting';
-import DataTable from '@/components/common/tables/DataTable';
-import { useCurrency } from '@/context/CurrencyContext';
-import { useTranslation } from 'react-i18next';
-import { GroupedExpenses, Expense } from '@/types/finance/expense';
 import { Dialog } from '@headlessui/react';
+import toast from 'react-hot-toast';
+
+import { GroupedExpenses, Expense } from '@/types/finance/expense';
 import { useDeleteExpense, useUpdateExpense } from '../services/expensesService';
+import DataTable from '@/components/common/tables/DataTable';
 import InputField from '@/components/common/forms/InputField';
 import SelectField from '@/components/common/forms/SelectField';
+
+import { formatCurrency, formatDate, truncateText } from '@/utils/formatting';
+import { useCurrency } from '@/context/CurrencyContext';
 import { useCategories } from '@/context/CategoryContext';
-import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
 
 type Props = {
   data: GroupedExpenses;
@@ -17,13 +21,13 @@ type Props = {
 };
 
 export default function GroupedExpensesList({ data, groupBy }: Props) {
-  const { currency } = useCurrency();
   const { t, i18n } = useTranslation();
+  const { currency } = useCurrency();
   const { categories } = useCategories();
   const { mutate: deleteExpense } = useDeleteExpense();
   const { mutate: updateExpense } = useUpdateExpense();
 
-  const [deletePendingId, setDeletePendingId] = useState<string | null>(null);
+  const [deletePendingExpense, setDeletePendingExpense] = useState<{ id: string; date: string } | null>(null);
   const [editItem, setEditItem] = useState<Expense | null>(null);
   const [editForm, setEditForm] = useState<Partial<Expense>>({});
 
@@ -32,15 +36,17 @@ export default function GroupedExpensesList({ data, groupBy }: Props) {
     setEditForm(item);
   };
 
-  const confirmDelete = (id: string) => setDeletePendingId(id);
+  const confirmDelete = (expense: Expense) => {
+    setDeletePendingExpense({ id: expense.id, date: expense.date });
+  };
 
   const handleDeleteConfirmed = () => {
-    if (!deletePendingId) return;
-    deleteExpense(deletePendingId, {
+    if (!deletePendingExpense) return;
+    deleteExpense(deletePendingExpense, {
       onSuccess: () => toast.success(t('expenses.toast.deleteSuccess')),
       onError: () => toast.error(t('expenses.toast.deleteError')),
     });
-    setDeletePendingId(null);
+    setDeletePendingExpense(null);
   };
 
   const handleEditChange = (
@@ -100,10 +106,7 @@ export default function GroupedExpensesList({ data, groupBy }: Props) {
     <>
       <div className="flex flex-col gap-6">
         {data.map(({ groupName, expenses }) => (
-          <div
-            key={groupName}
-            className="rounded-xl border border-l-4 border-primary bg-base-100 shadow-sm"
-          >
+          <div key={groupName} className="rounded-xl border border-l-4 border-primary bg-base-100 shadow-sm">
             <h3 className="text-lg font-semibold text-base-content mb-2 mt-2 ml-2">
               {formatGroupLabel(groupName)}
             </h3>
@@ -113,68 +116,76 @@ export default function GroupedExpensesList({ data, groupBy }: Props) {
               data={expenses}
               columns={[
                 {
-                  label: t('shared.date'),
+                  label: t('expenses.table.date'),
                   accessor: 'date',
                   format: formatDate,
-                  width: '100px',
+                  width: 'w-[80px]',
+                  sortable: true,
+                },
+                {
+                  label: t('expenses.table.name'),
+                  accessor: 'name',
+                  width: 'w-[120px] sm:w-[130px] lg:w-[200px]',
+                  sortable: true,
+                },
+                {
+                  label: t('expenses.table.description'),
+                  accessor: 'description',
+                  format: (val) => truncateText(val),
+                  width: 'w-[150px] sm:w-[180px] lg:w-[240px]',
                   sortable: true,
                   showOnMobile: false,
                 },
                 {
-                  label: t('shared.name'),
-                  accessor: 'name',
-                  width: '150px',
-                  sortable: true,
-                },
-                {
-                  label: t('shared.description'),
-                  accessor: 'description',
-                  format: (val) => truncateText(val),
-                  width: '400px',
-                  sortable: true,
-                },
-                {
-                  label: t('shared.amount'),
+                  label: t('expenses.table.amount'),
                   accessor: 'amount',
                   align: 'right',
                   format: (val) => formatCurrency(val, currency),
-                  width: '100px',
+                  width: 'w-[80px] sm:w-[100px]',
+                  sortable: true,
                 },
                 {
-                  label: t('shared.category'),
+                  label: t('expenses.table.category'),
                   accessor: 'categoryName',
+                  align: 'center',
                   format: (val) =>
                     val ? (
                       <span className="badge badge-sm badge-accent">{val}</span>
                     ) : (
                       <span className="text-base-content/40">–</span>
                     ),
-                  width: '150px',
+                  width: 'w-[100px] sm:w-[150px]',
+                  sortable: true,
+                  showOnMobile: false,
                 },
               ]}
               actionHandlers={{
                 onEdit: openEditModal,
-                onDelete: (row) => confirmDelete(row.id),
+                onDelete: (row) => confirmDelete(row),
               }}
             />
           </div>
         ))}
       </div>
 
-      {/* Delete confirmation dialog */}
-      <Dialog open={!!deletePendingId} onClose={() => setDeletePendingId(null)} className="fixed z-50 inset-0 flex items-center justify-center">
+      {/* Delete Confirmation */}
+      <Dialog open={!!deletePendingExpense} onClose={() => setDeletePendingExpense(null)} className="fixed z-50 inset-0 flex items-center justify-center">
         <div className="fixed inset-0 bg-black opacity-30" />
         <div className="relative bg-base-100 rounded-lg p-6 shadow-lg">
           <Dialog.Title className="text-lg font-semibold">{t('shared.confirmDelete')}</Dialog.Title>
           <Dialog.Description className="mt-2">{t('expenses.confirmDeleteText')}</Dialog.Description>
           <div className="mt-4 flex justify-end gap-2">
-            <button onClick={() => setDeletePendingId(null)} className="btn btn-ghost">{t('shared.cancel')}</button>
-            <button onClick={handleDeleteConfirmed} className="btn btn-error">{t('shared.delete')}</button>
+            <button onClick={() => setDeletePendingExpense(null)} className="btn btn-ghost">
+              {t('shared.cancel')}
+            </button>
+            <button onClick={handleDeleteConfirmed} className="btn btn-error">
+              {t('shared.delete')}
+            </button>
           </div>
         </div>
       </Dialog>
 
-      {/* Edit modal */}
+      {/* Edit Modal */}
       <Dialog open={!!editItem} onClose={() => setEditItem(null)} className="fixed z-50 inset-0 flex items-center justify-center">
         <div className="fixed inset-0 bg-black opacity-30" />
         <div className="relative bg-base-100 rounded-lg p-6 shadow-lg w-full max-w-md">

--- a/frontend/src/features/expenses/services/expensesService.ts
+++ b/frontend/src/features/expenses/services/expensesService.ts
@@ -82,19 +82,34 @@ async function updateExpenseApi({
 }: {
   id: string;
   data: UpdateExpenseDto;
-}): Promise<void> {
-  await apiFetch(`${API_BASE_URL}/${id}`, {
+}): Promise<Expense> {
+  const result = await apiFetch<Expense | null>(`${API_BASE_URL}/${id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   });
+
+  if (!result) {
+    throw new Error('Failed to update expense');
+  }
+
+  return result;
 }
 
-async function deleteExpenseApi(id: string): Promise<void> {
+
+
+async function deleteExpenseApi({
+  id,
+}: {
+  id: string;
+  date: string;
+}): Promise<void> {
   await apiFetch(`${API_BASE_URL}/${id}`, {
     method: 'DELETE',
   });
 }
+
+
 
 // === REACT QUERY HOOKS ===
 export function useExpenses(filters: FetchExpenseOptions) {
@@ -126,9 +141,18 @@ export function useCreateExpense() {
 
   return useMutation({
     mutationFn: createExpenseApi,
-    onSuccess: () => {
+    onSuccess: (createdExpense) => {
+      const date = new Date(createdExpense.date);
+      const month = date.getMonth() + 1;      
+      const year = date.getFullYear();
+
+      const lastMonth = month === 1 ? 12 : month - 1;
+      const lastMonthYear = month === 1 ? year - 1 : year;
+
       queryClient.invalidateQueries({ queryKey: ['expenses'] });
-      queryClient.invalidateQueries({ queryKey: ['expensesOverview'] });
+      queryClient.invalidateQueries({queryKey: ['expensesOverview', month, year]});
+      queryClient.invalidateQueries({queryKey: ['expensesOverview', lastMonth, lastMonthYear]});
+      queryClient.invalidateQueries({queryKey: ['dashboardSummary', month, year]});
     },
   });
 }
@@ -138,10 +162,19 @@ export function useUpdateExpense() {
 
   return useMutation({
     mutationFn: (payload: { id: string; data: UpdateExpenseDto }) => updateExpenseApi(payload),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['expenses'] });
-      queryClient.invalidateQueries({ queryKey: ['expensesOverview'] });
-    },
+      onSuccess: (updatedExpense) => {
+        const date = new Date(updatedExpense.date);
+        const month = date.getMonth() + 1;
+        const year = date.getFullYear();
+
+        const lastMonth = month === 1 ? 12 : month - 1;
+        const lastMonthYear = month === 1 ? year - 1 : year;
+
+        queryClient.invalidateQueries({ queryKey: ['expenses'] });
+        queryClient.invalidateQueries({ queryKey: ['expensesOverview', month, year] });
+        queryClient.invalidateQueries({ queryKey: ['expensesOverview', lastMonth, lastMonthYear] });
+        queryClient.invalidateQueries({ queryKey: ['dashboardSummary', month, year] });
+      },
   });
 }
 
@@ -150,12 +183,22 @@ export function useDeleteExpense() {
 
   return useMutation({
     mutationFn: deleteExpenseApi,
-    onSuccess: () => {
+    onSuccess: (_, { date }) => {
+      const d = new Date(date);
+      const month = d.getMonth() + 1;
+      const year = d.getFullYear();
+      const lastMonth = month === 1 ? 12 : month - 1;
+      const lastMonthYear = month === 1 ? year - 1 : year;
+
       queryClient.invalidateQueries({ queryKey: ['expenses'] });
-      queryClient.invalidateQueries({ queryKey: ['expensesOverview'] });
+      queryClient.invalidateQueries({ queryKey: ['expensesOverview', month, year] });
+      queryClient.invalidateQueries({ queryKey: ['expensesOverview', lastMonth, lastMonthYear] });
+      queryClient.invalidateQueries({ queryKey: ['dashboardSummary', month, year] });
+      queryClient.invalidateQueries({ queryKey: ['dashboardSummary', lastMonth, lastMonthYear] });
     },
   });
 }
+
 
 // === UTILITY ===
 export function isGroupedExpenses(data: Expense[] | GroupedExpenses): data is GroupedExpenses {

--- a/frontend/src/features/goals/services/GoalsService.ts
+++ b/frontend/src/features/goals/services/GoalsService.ts
@@ -44,15 +44,18 @@ async function updateGoalApi({
 }: {
   id: string;
   data: UpdateGoalDto;
-}): Promise<void> {
-  await apiFetch(`${API_BASE_URL}/${id}`, {
+}): Promise<GoalDto> {
+  const result = await apiFetch<GoalDto>(`${API_BASE_URL}/${id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   });
+
+  if (!result) throw new Error('Failed to update goal');
+  return result;
 }
 
-async function deleteGoalApi(id: string): Promise<void> {
+async function deleteGoalApi({ id }: { id: string }): Promise<void> {
   await apiFetch(`${API_BASE_URL}/${id}`, {
     method: 'DELETE',
   });
@@ -64,12 +67,15 @@ async function contributeGoalApi({
 }: {
   id: string;
   data: GoalContributionDto;
-}): Promise<void> {
-  await apiFetch(`${API_BASE_URL}/${id}/contribute`, {
+}): Promise<GoalDto> {
+  const result = await apiFetch<GoalDto>(`${API_BASE_URL}/${id}/contribute`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   });
+
+  if (!result) throw new Error('Failed to contribute to goal');
+  return result;
 }
 
 // === REACT QUERY HOOKS ===
@@ -106,8 +112,13 @@ export function useCreateGoal() {
   return useMutation({
     mutationFn: createGoalApi,
     onSuccess: () => {
+      const date = new Date();
+      const month = date.getMonth() + 1;
+      const year = date.getFullYear();
+
       queryClient.invalidateQueries({ queryKey: ['goals'] });
       queryClient.invalidateQueries({ queryKey: ['goalsOverview'] });
+      queryClient.invalidateQueries({ queryKey: ['dashboardSummary', month, year] });
     },
   });
 }
@@ -118,8 +129,13 @@ export function useUpdateGoal() {
   return useMutation({
     mutationFn: (payload: { id: string; data: UpdateGoalDto }) => updateGoalApi(payload),
     onSuccess: () => {
+      const date = new Date();
+      const month = date.getMonth() + 1;
+      const year = date.getFullYear();
+
       queryClient.invalidateQueries({ queryKey: ['goals'] });
       queryClient.invalidateQueries({ queryKey: ['goalsOverview'] });
+      queryClient.invalidateQueries({ queryKey: ['dashboardSummary', month, year] });
     },
   });
 }
@@ -128,10 +144,15 @@ export function useDeleteGoal() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: deleteGoalApi,
+    mutationFn: (id: string) => deleteGoalApi({ id }),
     onSuccess: () => {
+      const deletedDate = new Date();
+      const month = deletedDate.getMonth() + 1;
+      const year = deletedDate.getFullYear();
+
       queryClient.invalidateQueries({ queryKey: ['goals'] });
       queryClient.invalidateQueries({ queryKey: ['goalsOverview'] });
+      queryClient.invalidateQueries({ queryKey: ['dashboardSummary', month, year] });
     },
   });
 }
@@ -142,8 +163,13 @@ export function useContributeGoal() {
   return useMutation({
     mutationFn: (payload: { id: string; data: GoalContributionDto }) => contributeGoalApi(payload),
     onSuccess: () => {
+      const date = new Date();
+      const month = date.getMonth() + 1;
+      const year = date.getFullYear();
+
       queryClient.invalidateQueries({ queryKey: ['goals'] });
       queryClient.invalidateQueries({ queryKey: ['goalsOverview'] });
+      queryClient.invalidateQueries({ queryKey: ['dashboardSummary', month, year] });
     },
   });
 }

--- a/frontend/src/pages/app/DashboardPage.tsx
+++ b/frontend/src/pages/app/DashboardPage.tsx
@@ -5,9 +5,12 @@ import LoadingSpinner from '@/components/common/LoadingSpinner';
 import DashboardHeader from '@/features/dashboard/components/DashboardHeader';
 import RecentActivity from '@/features/dashboard/components/RecentActivity';
 import DashboardInsights from '@/features/dashboard/components/DashboardInsights';
+import { formatCurrency } from '@/utils/formatting';
+import { useCurrency } from '@/context/CurrencyContext';
 
 export default function DashboardPage() {
   const { data: summary, isLoading } = useDashboardSummary();
+  const { currency } = useCurrency();
 
   if (isLoading || !summary) return <LoadingSpinner />;
 
@@ -20,37 +23,33 @@ export default function DashboardPage() {
           title="Expenses This Month"
           value={summary.totalSpentThisMonth}
           showCurrency
+          showProgress={false}
           icon={<AppIcons.wallet className="w-6 h-6 text-red-400" />}
           to="/expenses"
           bg="from-red-500/50 to-red-900/70"
           border="border-red-500/20"
-          progress={summary.spendingIsUp ? 80 : 50}
         />
 
         <DashboardCard
           title="Income Received"
           value={summary.incomeReceivedThisMonth}
           showCurrency
+          showProgress={false}
           icon={<AppIcons.income className="w-6 h-6 text-green-400" />}
           to="/income"
           bg="from-green-500/50 to-green-900/70"
           border="border-green-500/20"
-          progress={100}
         />
 
         <DashboardCard
           title="Active Budgets"
           value={summary.activeBudgets}
           suffix={summary.activeBudgets ? 'active' : ''}
+          showProgress={false}
           icon={<AppIcons.landmark className="w-6 h-6 text-blue-400" />}
           to="/budgets"
           bg="from-blue-500/50 to-blue-900/70"
           border="border-blue-500/20"
-          progress={
-            summary.activeBudgets && summary.budgetAllocatedTotal
-              ? Math.min((summary.budgetSpentTotal / summary.budgetAllocatedTotal) * 100, 100)
-              : 0
-          }
           emptyMessage={summary.activeBudgets === 0 ? 'Create your first budget' : undefined}
         />
 
@@ -58,6 +57,7 @@ export default function DashboardPage() {
           title="Savings Total"
           value={summary.totalSavings}
           showCurrency
+          showProgress={false}
           icon={<AppIcons.savings className="w-6 h-6 text-orange-300" />}
           to="/goals"
           bg="from-orange-500/50 to-orange-900/70"
@@ -69,28 +69,26 @@ export default function DashboardPage() {
         <DashboardCard
           title="Financial Goals"
           value={summary.totalGoals}
-          suffix={summary.totalGoals ? 'Goals' : ''}
+          suffix={summary.totalGoals ? 'Goals' : ''}          
+          showProgress={false}
           icon={<AppIcons.goal className="w-6 h-6 text-pink-400" />}
           to="/goals"
           bg="from-pink-500/50 to-pink-900/70"
-          border="border-pink-500/20"
-          progress={
-            summary.totalGoals
-              ? Math.min((summary.goalsNearCompletion / summary.totalGoals) * 100, 100)
-              : 0
-          }
+          border="border-pink-500/20"          
           emptyMessage={summary.totalGoals === 0 ? 'Set up your first goal' : undefined}
         />
 
         <DashboardCard
-          title="Cashflow Stats"
-          value={0}
+          title="Cashflow Balance"
+          value={summary.monthlyCashflowBalance}
+          showCurrency
+          showProgress={false}
           icon={<AppIcons.goal className="w-6 h-6 text-purple-400" />}
           to="/cashflow"
           bg="from-purple-500/50 to-purple-900/70"
           border="border-purple-500/20"
-          progress={0}
           emptyMessage="Cashflow stats coming soon"
+          subtext={`Income: ${formatCurrency(summary.monthlyCashflowIncome,currency)}, – Expenses: ${formatCurrency(summary.monthlyCashflowExpenses, currency)}`}
         />
       </div>
 

--- a/frontend/src/types/finance/DashboardSummary.ts
+++ b/frontend/src/types/finance/DashboardSummary.ts
@@ -24,6 +24,9 @@ export type DashboardSummary = {
   savingsGoalProgressPercent: number;
   nextGoalName: string | null;
   nextGoalDueDate: string | null;
+  monthlyCashflowBalance: number;
+  monthlyCashflowIncome: number;
+  monthlyCashflowExpenses: number;
   lastUpdated: string;
   alertsCount: number;
 };


### PR DESCRIPTION
### 🔄 Dashboard Summary Invalidation
We now correctly **invalidate the dashboard cache** when making changes in:
- ✅ Expenses
- ✅ Incomes
- ✅ Goals
- ✅ Budgets
- ✅ Cashflow

This ensures the dashboard always reflects the most current data without needing a manual refresh.

---

### 🧩 DashboardCard Updates
- Supports:
  - `prefix`, `suffix`
  - Empty value fallback message
  - Optional subtext with cleaner layout

