### PR TITLE
Admin Manual Subscription Override System

### DIFF
--- a/backend/Budgenix.API/Controllers/AdminController.cs
+++ b/backend/Budgenix.API/Controllers/AdminController.cs
@@ -32,6 +32,32 @@ namespace Budgenix.API.Controllers
             return Ok(await _adminService.GetUserDetailsAsync(id));
         }
 
+        [HttpPost("user/{id}/grant-subscription")]
+        public async Task<IActionResult> GrantManualSubscription(string id, [FromBody] GrantSubscriptionOverrideDto dto)
+        {
+            if (id != dto.UserId)
+                return BadRequest("User ID mismatch.");
+
+            var result = await _adminService.GrantManualSubscriptionAsync(dto);
+            return result ? Ok(new { message = "Subscription override granted." }) : BadRequest("Failed to grant override.");
+        }
+
+        [HttpGet("user/{id}/overrides")]
+        public async Task<IActionResult> GetUserOverrides(string id)
+        {
+            var overrides = await _adminService.GetManualSubscriptionOverridesAsync(id);
+            return Ok(overrides);
+        }
+
+        [HttpDelete("user/{userId}/override/{overrideId}")]
+        public async Task<IActionResult> RevokeManualSubscription(string userId, Guid overrideId, [FromQuery] string? reason)
+        {
+            var success = await _adminService.RevokeManualSubscriptionAsync(overrideId, reason);
+            return success ? Ok(new { message = "Override revoked" }) : BadRequest("Failed to revoke override");
+        }
+
+
+
         [HttpDelete("user/{id}")]
         public async Task<ActionResult<AdminDeleteResultDto>> DeleteUser(string id)
         {

--- a/backend/Budgenix.API/Controllers/UserController.cs
+++ b/backend/Budgenix.API/Controllers/UserController.cs
@@ -51,6 +51,13 @@ public class UserController : ControllerBase
         }
     }
 
+    [HttpGet("me/tier")]
+    public async Task<IActionResult> GetMySubscriptionTier()
+    {
+        var tier = await _userService.GetEffectiveSubscriptionTierAsync();
+        return Ok(new { tier });
+    }
+
 
     [HttpGet("me/currency")]
     public async Task<IActionResult> GetCurrency()

--- a/backend/Budgenix.API/Data/BudgenixDbContext.cs
+++ b/backend/Budgenix.API/Data/BudgenixDbContext.cs
@@ -26,6 +26,7 @@ namespace Budgenix.Data
 
         public DbSet<SystemNotification> SystemNotifications { get; set; }
         public DbSet<UserNotificationRead> UserNotificationReads { get; set; }
+        public DbSet<ManualSubscriptionOverride> ManualSubscriptionOverrides { get; set; }
 
 
         protected override void OnModelCreating(ModelBuilder builder)

--- a/backend/Budgenix.API/Dtos/Admin/AdminUserDetailsDto.cs
+++ b/backend/Budgenix.API/Dtos/Admin/AdminUserDetailsDto.cs
@@ -4,5 +4,7 @@
     {
         public UserStatsDto Stats { get; set; } = new();
         public List<AdminAuditLogDto> RecentActivity { get; set; } = new();
+        public List<ManualSubscriptionOverrideDto> ManualOverrides { get; set; } = new();
+
     }
 }

--- a/backend/Budgenix.API/Dtos/Admin/GrantSubscriptionOverrideDto.cs
+++ b/backend/Budgenix.API/Dtos/Admin/GrantSubscriptionOverrideDto.cs
@@ -1,0 +1,21 @@
+﻿using Budgenix.Models.Users;
+using System.ComponentModel.DataAnnotations;
+
+namespace Budgenix.Dtos.Admin
+{
+    public class GrantSubscriptionOverrideDto
+    {
+        [Required]
+        public string UserId { get; set; } = default!;
+
+        [Required]
+        public SubscriptionTypeEnum Tier { get; set; }
+
+        [Required]
+        public DateTime EndDate { get; set; }
+
+        public string? CustomMessage { get; set; }
+
+        public bool SendEmail { get; set; } = false;
+    }
+}

--- a/backend/Budgenix.API/Dtos/Admin/ManualSubscriptionOverride.cs
+++ b/backend/Budgenix.API/Dtos/Admin/ManualSubscriptionOverride.cs
@@ -1,0 +1,18 @@
+﻿using Budgenix.Models.Users;
+
+namespace Budgenix.Dtos.Admin
+{
+    public class ManualSubscriptionOverrideDto
+    {
+        public Guid Id { get; set; }
+        public string UserId { get; set; }
+        public SubscriptionTypeEnum Tier { get; set; }
+        public DateTime StartDate { get; set; }
+        public DateTime EndDate { get; set; }
+        public string? CustomMessage { get; set; }
+        public bool SentEmail { get; set; }
+        public string? CreatedByAdminId { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+
+}

--- a/backend/Budgenix.API/Dtos/Admin/RevokeManualSubscriptionDto.cs
+++ b/backend/Budgenix.API/Dtos/Admin/RevokeManualSubscriptionDto.cs
@@ -1,0 +1,9 @@
+﻿namespace Budgenix.Dtos.Admin
+{
+    public class RevokeManualSubscriptionDto
+    {
+        public Guid OverrideId { get; set; }
+        public string? Reason { get; set; }
+    }
+
+}

--- a/backend/Budgenix.API/Dtos/Users/UserDto.cs
+++ b/backend/Budgenix.API/Dtos/Users/UserDto.cs
@@ -19,6 +19,8 @@ namespace Budgenix.Dtos.Users
         public bool SubscriptionIsActive { get; set; }
         public DateTime? SubscriptionStartDate { get; set; }
         public DateTime? SubscriptionEndDate { get; set; }
+        public DateTime? OverrideSubscriptionEndDate { get; set; }
+
         public BillingCycleEnum BillingCycle { get; set; }
         public string? ReferralCode { get; set; }
         public string Currency { get; set; } = "USD";

--- a/backend/Budgenix.API/Migrations/20250722113018_AddManualSubscriptionOverrides.Designer.cs
+++ b/backend/Budgenix.API/Migrations/20250722113018_AddManualSubscriptionOverrides.Designer.cs
@@ -4,6 +4,7 @@ using Budgenix.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Budgenix.API.Migrations
 {
     [DbContext(typeof(BudgenixDbContext))]
-    partial class BudgenixDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250722113018_AddManualSubscriptionOverrides")]
+    partial class AddManualSubscriptionOverrides
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -381,6 +384,9 @@ namespace Budgenix.API.Migrations
                         .HasMaxLength(100)
                         .HasColumnType("nvarchar(100)");
 
+                    b.Property<string>("GrantedByUserId")
+                        .HasColumnType("nvarchar(max)");
+
                     b.Property<Guid?>("HouseholdId")
                         .HasColumnType("uniqueidentifier");
 
@@ -502,11 +508,11 @@ namespace Budgenix.API.Migrations
                     b.Property<string>("CreatedByAdminId")
                         .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("CustomMessage")
-                        .HasColumnType("nvarchar(max)");
-
                     b.Property<DateTime>("EndDate")
                         .HasColumnType("datetime2");
+
+                    b.Property<string>("Reason")
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<bool>("SentEmail")
                         .HasColumnType("bit");

--- a/backend/Budgenix.API/Migrations/20250722113018_AddManualSubscriptionOverrides.cs
+++ b/backend/Budgenix.API/Migrations/20250722113018_AddManualSubscriptionOverrides.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Budgenix.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddManualSubscriptionOverrides : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ManualSubscriptionOverrides",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    UserId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Tier = table.Column<int>(type: "int", nullable: false),
+                    StartDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    EndDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Reason = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    SentEmail = table.Column<bool>(type: "bit", nullable: false),
+                    CreatedByAdminId = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ManualSubscriptionOverrides", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ManualSubscriptionOverrides_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ManualSubscriptionOverrides_UserId",
+                table: "ManualSubscriptionOverrides",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ManualSubscriptionOverrides");
+        }
+    }
+}

--- a/backend/Budgenix.API/Migrations/20250722134736_RenameReasonToCustomMessage.Designer.cs
+++ b/backend/Budgenix.API/Migrations/20250722134736_RenameReasonToCustomMessage.Designer.cs
@@ -4,6 +4,7 @@ using Budgenix.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Budgenix.API.Migrations
 {
     [DbContext(typeof(BudgenixDbContext))]
-    partial class BudgenixDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250722134736_RenameReasonToCustomMessage")]
+    partial class RenameReasonToCustomMessage
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -380,6 +383,9 @@ namespace Budgenix.API.Migrations
                         .IsRequired()
                         .HasMaxLength(100)
                         .HasColumnType("nvarchar(100)");
+
+                    b.Property<string>("GrantedByUserId")
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<Guid?>("HouseholdId")
                         .HasColumnType("uniqueidentifier");

--- a/backend/Budgenix.API/Migrations/20250722134736_RenameReasonToCustomMessage.cs
+++ b/backend/Budgenix.API/Migrations/20250722134736_RenameReasonToCustomMessage.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Budgenix.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class RenameReasonToCustomMessage : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "Reason",
+                table: "ManualSubscriptionOverrides",
+                newName: "CustomMessage");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "CustomMessage",
+                table: "ManualSubscriptionOverrides",
+                newName: "Reason");
+        }
+    }
+}

--- a/backend/Budgenix.API/Migrations/20250722180850_AddCustomMessageToManualSubscriptionOverrides.Designer.cs
+++ b/backend/Budgenix.API/Migrations/20250722180850_AddCustomMessageToManualSubscriptionOverrides.Designer.cs
@@ -4,6 +4,7 @@ using Budgenix.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Budgenix.API.Migrations
 {
     [DbContext(typeof(BudgenixDbContext))]
-    partial class BudgenixDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250722180850_AddCustomMessageToManualSubscriptionOverrides")]
+    partial class AddCustomMessageToManualSubscriptionOverrides
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Budgenix.API/Migrations/20250722180850_AddCustomMessageToManualSubscriptionOverrides.cs
+++ b/backend/Budgenix.API/Migrations/20250722180850_AddCustomMessageToManualSubscriptionOverrides.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Budgenix.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCustomMessageToManualSubscriptionOverrides : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "GrantedByUserId",
+                table: "AspNetUsers");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "GrantedByUserId",
+                table: "AspNetUsers",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+    }
+}

--- a/backend/Budgenix.API/Models/Audit/AuditActionEnum.cs
+++ b/backend/Budgenix.API/Models/Audit/AuditActionEnum.cs
@@ -39,6 +39,8 @@
         AdminResetPassword,
         AdminPromoteToAdmin,
         AdminChangeSubscription,
+        AdminGrantManualSubscription,
+        AdminRevokeManualSubscription,
 
         // Authentication
         UserLogin,

--- a/backend/Budgenix.API/Models/Users/ApplicationUser.cs
+++ b/backend/Budgenix.API/Models/Users/ApplicationUser.cs
@@ -68,8 +68,6 @@ namespace Budgenix.Models.Users
         [MaxLength(50)]
         public string? ReferralCode { get; set; }  // unique referral code for this user
 
-        public string? GrantedByUserId { get; set; }  // user ID of who granted tier manually
-
         // Household/group sharing (optional)
 
         public Guid? HouseholdId { get; set; }  // Optional

--- a/backend/Budgenix.API/Models/Users/ManualSubscriptionOverride.cs
+++ b/backend/Budgenix.API/Models/Users/ManualSubscriptionOverride.cs
@@ -1,0 +1,18 @@
+﻿namespace Budgenix.Models.Users
+{
+    public class ManualSubscriptionOverride
+    {
+        public Guid Id { get; set; }
+        public string UserId { get; set; } = default!;
+        public SubscriptionTypeEnum Tier { get; set; }
+        public DateTime StartDate { get; set; } = DateTime.UtcNow;
+        public DateTime EndDate { get; set; }
+        public string? CustomMessage { get; set; }
+        public bool SentEmail { get; set; } = false;
+        public string? CreatedByAdminId { get; set; }
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+        public virtual ApplicationUser User { get; set; } = default!;
+    }
+
+}

--- a/backend/Budgenix.API/Services/Admin/AdminService.cs
+++ b/backend/Budgenix.API/Services/Admin/AdminService.cs
@@ -6,6 +6,8 @@ using Budgenix.Services.Audit;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
+using Budgenix.Services.Email;
+using System.Security.Claims;
 
 namespace Budgenix.Services.Admin
 {
@@ -15,17 +17,20 @@ namespace Budgenix.Services.Admin
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly IAuditService _auditService;
         private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IEmailService _emailService;
 
         public AdminService(
             BudgenixDbContext context,
             UserManager<ApplicationUser> userManager,
             IAuditService auditService,
-            IHttpContextAccessor httpContextAccessor)
+            IHttpContextAccessor httpContextAccessor,
+            IEmailService emailService)
         {
             _context = context;
             _userManager = userManager;
             _auditService = auditService;
             _httpContextAccessor = httpContextAccessor;
+            _emailService = emailService;
         }
         public async Task<List<AdminUserDto>> GetAllUsersAsync()
         {
@@ -60,6 +65,8 @@ namespace Budgenix.Services.Admin
             var user = await _context.Users.FindAsync(id);
             if (user == null) throw new Exception("User not found");
 
+            var manualOverrides = await GetManualSubscriptionOverridesAsync(user.Id);
+
             var roles = await _userManager.GetRolesAsync(user);
 
             var expenses = await _context.Expenses.CountAsync(e => e.UserId == id);
@@ -67,7 +74,7 @@ namespace Budgenix.Services.Admin
             var budgets = await _context.Budgets.CountAsync(b => b.UserId == id);
             var goals = await _context.Goals.CountAsync(g => g.UserId == id);
             var recentLogs = await GetRecentUserActivityAsync(id);
-
+            
             return new AdminUserDetailsDto
             {
                 Id = user.Id,
@@ -94,8 +101,135 @@ namespace Budgenix.Services.Admin
                     Budgets = budgets,
                     Goals = goals
                 },
-                RecentActivity = recentLogs
+                RecentActivity = recentLogs,
+               
+                ManualOverrides = manualOverrides
             };
+        }
+
+
+        public async Task<bool> GrantManualSubscriptionAsync(GrantSubscriptionOverrideDto dto)
+        {
+            var user = await _userManager.FindByIdAsync(dto.UserId);
+            if (user == null)
+                throw new Exception("User not found");
+
+            var now = DateTime.UtcNow;
+            var adminId = GetCurrentUserId();
+
+            // Save override entry
+            var overrideEntry = new ManualSubscriptionOverride
+            {
+                UserId = user.Id,
+                Tier = dto.Tier,
+                StartDate = now,
+                EndDate = dto.EndDate,
+                CustomMessage = dto.CustomMessage,
+                SentEmail = dto.SendEmail,
+                CreatedByAdminId = adminId,
+                CreatedAt = now
+            };
+
+            _context.ManualSubscriptionOverrides.Add(overrideEntry);
+
+            // Update user subscription fields
+            user.SubscriptionTier = dto.Tier;
+            user.SubscriptionIsActive = true;
+            user.SubscriptionStartDate = now;
+            user.SubscriptionEndDate = dto.EndDate;
+            user.SubscriptionGracePeriodEnd = null;
+            user.IsTrial = false;
+            user.TrialEndDate = null;
+            user.DiscountPercent = null;
+            user.DiscountEndDate = null;
+
+            _context.Users.Update(user);
+
+            await _context.SaveChangesAsync();
+
+            await _auditService.LogAsync(
+                userId: adminId,
+                action: AuditActionEnum.AdminGrantManualSubscription,
+                entityType: nameof(ManualSubscriptionOverride),
+                entityId: overrideEntry.Id.ToString(),
+                targetUserId: user.Id,
+                newValues: JsonConvert.SerializeObject(overrideEntry),
+                metadata: "Admin granted manual subscription override"
+            );
+
+            if (dto.SendEmail)
+            {
+                await _emailService.SendSubscriptionGrantedEmailAsync(
+                    toEmail: user.Email,
+                    firstName: user.FirstName,
+                    tier: dto.Tier,
+                    endDate: dto.EndDate
+                );
+            }
+
+            return true;
+        }
+
+
+        public async Task<List<ManualSubscriptionOverrideDto>> GetManualSubscriptionOverridesAsync(string userId)
+        {
+            return await _context.ManualSubscriptionOverrides
+                .Where(o => o.UserId == userId)
+                .OrderByDescending(o => o.CreatedAt)
+                .Select(o => new ManualSubscriptionOverrideDto
+                {
+                    Id = o.Id,
+                    UserId = o.UserId,
+                    Tier = o.Tier,
+                    StartDate = o.StartDate,
+                    EndDate = o.EndDate,
+                    CustomMessage = o.CustomMessage,
+                    SentEmail = o.SentEmail,
+                    CreatedByAdminId = o.CreatedByAdminId,
+                    CreatedAt = o.CreatedAt
+                })
+                .ToListAsync();
+        }
+
+
+        public async Task<bool> RevokeManualSubscriptionAsync(Guid overrideId,string userId, string? reason = null)
+        {
+            var user = await _userManager.FindByIdAsync(userId);
+            if (user == null)
+                throw new Exception("User not found");
+
+
+            var overrideEntry = await _context.ManualSubscriptionOverrides.FindAsync(overrideId);
+            if (overrideEntry == null)
+                throw new Exception("Override not found");
+
+            if (overrideEntry.UserId != user.Id)
+                throw new Exception("Override does not belong to the specified user.");
+
+
+            _context.ManualSubscriptionOverrides.Remove(overrideEntry);
+            await _context.SaveChangesAsync();
+
+            await _auditService.LogAsync(
+                userId: GetCurrentUserId(),
+                action: AuditActionEnum.AdminRevokeManualSubscription,
+                entityType: nameof(ManualSubscriptionOverride),
+                entityId: overrideEntry.Id.ToString(),
+                targetUserId: overrideEntry.UserId,
+                oldValues: JsonConvert.SerializeObject(overrideEntry),
+                metadata: $"Revoked by {GetCurrentUserId()}: {reason ?? "No message"}"
+
+            );
+
+            await _emailService.SendSubscriptionRevokedEmailAsync(
+                toEmail: user.Email,
+                firstName: user.FirstName,
+                tier: overrideEntry.Tier,
+                endDate: overrideEntry.EndDate
+            );
+
+
+            return true;
         }
 
 
@@ -217,7 +351,9 @@ namespace Budgenix.Services.Admin
 
         private string GetCurrentUserId()
         {
-            return _httpContextAccessor.HttpContext?.User?.FindFirst("sub")?.Value ?? "unknown";
+            var user = _httpContextAccessor.HttpContext?.User;
+            return user?.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? "unknown";
         }
+
     }
 }

--- a/backend/Budgenix.API/Services/Admin/IAdminService.cs
+++ b/backend/Budgenix.API/Services/Admin/IAdminService.cs
@@ -1,10 +1,14 @@
 ﻿using Budgenix.Dtos.Admin;
+using Budgenix.Models.Users;
 
 namespace Budgenix.Services.Admin
 {
     public interface IAdminService
     {
         Task<List<AdminUserDto>> GetAllUsersAsync();
+        Task<bool> GrantManualSubscriptionAsync(GrantSubscriptionOverrideDto dto);
+        Task<List<ManualSubscriptionOverrideDto>> GetManualSubscriptionOverridesAsync(string userId);
+        Task<bool> RevokeManualSubscriptionAsync(Guid overrideId, string userId, string? reason = null);
         Task<AdminUserDetailsDto> GetUserDetailsAsync(string id);
         Task<AdminDeleteResultDto> DeleteUserAsync(string id);
         Task DeleteUserItemAsync(string id, string type, Guid itemId);

--- a/backend/Budgenix.API/Services/Email/EmailService.cs
+++ b/backend/Budgenix.API/Services/Email/EmailService.cs
@@ -1,11 +1,8 @@
-﻿using System.Net;
+﻿using Budgenix.Models.Users;
+using System.Net;
 
 namespace Budgenix.Services.Email
 {
-    public interface IEmailService
-    {
-        Task SendEmailConfirmationAsync(string toEmail, string confirmationLink);
-    }
 
     public class EmailService : IEmailService
     {
@@ -64,8 +61,8 @@ namespace Budgenix.Services.Email
                             </td>
                           </tr>
                         </table>"
-                        },
-                        Recipients = new List<SparkPost.Recipient>
+                },
+                Recipients = new List<SparkPost.Recipient>
                         {
                             new SparkPost.Recipient
                             {
@@ -75,7 +72,7 @@ namespace Budgenix.Services.Email
                                 }
                             }
                         }
-                    };
+            };
 
 
             var response = await client.Transmissions.Send(transmission);
@@ -85,6 +82,146 @@ namespace Budgenix.Services.Email
                 throw new Exception("Failed to send confirmation email.");
             }
         }
+
+        public async Task SendSubscriptionGrantedEmailAsync(string toEmail, string firstName, SubscriptionTypeEnum tier, DateTime endDate)
+        {
+            var apiKey = _config["SparkPost:ApiKey"];
+            var client = new SparkPost.Client(apiKey)
+            {
+                ApiHost = "https://api.eu.sparkpost.com"
+            };
+
+            var transmission = new SparkPost.Transmission
+            {
+                Content = new SparkPost.Content
+                {
+                    From = new SparkPost.Address
+                    {
+                        Email = "no-reply@mail.vebjornbaustad.no",
+                        Name = "Budgenix"
+                    },
+                    Subject = $"You've been granted {tier} access!",
+                    Html = $@"
+                <table style='width:100%; max-width:600px; margin:auto; font-family:Arial, sans-serif; border-collapse:collapse; background-color:#FDFBF7; border:1px solid #E8DFD2;'>
+                  <tr>
+                    <td style='background-color:#4C7C59; padding:20px; text-align:center; color:#FFFFFF;'>
+                      <h1 style='margin:0; font-size:24px;'>Budgenix</h1>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style='padding:30px; background-color:#F5F1EA;'>
+                      <p style='font-size:16px; color:#2A2927; margin:0 0 16px;'>Hi {firstName},</p>
+                      <p style='font-size:16px; color:#2A2927; margin:0 0 24px;'>
+                        🎉 You've been granted <strong>{tier}</strong> access on Budgenix until <strong>{endDate:MMMM dd, yyyy}</strong> — completely free!
+                      </p>
+                      <p style='font-size:14px; color:#6b7280; margin:0;'>
+                        If you have any questions or feedback, just reply to this email.
+                      </p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style='background-color:#E8DFD2; color:#6b7280; padding:15px; text-align:center; font-size:12px;'>
+                      © {DateTime.UtcNow.Year} Budgenix. All rights reserved.
+                    </td>
+                  </tr>
+                </table>"
+                },
+                Recipients = new List<SparkPost.Recipient>
+        {
+            new SparkPost.Recipient
+            {
+                Address = new SparkPost.Address
+                {
+                    Email = toEmail
+                }
+            }
+        }
+            };
+
+            var response = await client.Transmissions.Send(transmission);
+            if (response.StatusCode != HttpStatusCode.OK &&
+                response.StatusCode != HttpStatusCode.Accepted)
+            {
+                throw new Exception("Failed to send subscription grant email.");
+            }
+        }
+
+        public async Task SendSubscriptionRevokedEmailAsync(string toEmail, string firstName, SubscriptionTypeEnum tier, DateTime endDate, string? customMessage)
+        {
+            var apiKey = _config["SparkPost:ApiKey"];
+            var client = new SparkPost.Client(apiKey)
+            {
+                ApiHost = "https://api.eu.sparkpost.com"
+            };
+
+            var messageBody = $@"
+                <p style='font-size:16px; color:#2A2927; margin:0 0 24px;'>
+                    Your <strong>{tier}</strong> access on Budgenix has ended as of <strong>{endDate:MMMM dd, yyyy}</strong>.
+                </p>";
+
+            if (!string.IsNullOrWhiteSpace(customMessage))
+            {
+                messageBody += $@"
+                    <p style='font-size:16px; color:#2A2927; margin:0 0 24px;'>
+                        ✉️ Message from the admin:<br />
+                        <em>{WebUtility.HtmlEncode(customMessage)}</em>
+                    </p>";
+            }
+
+            var transmission = new SparkPost.Transmission
+            {
+                Content = new SparkPost.Content
+                {
+                    From = new SparkPost.Address
+                    {
+                        Email = "no-reply@mail.vebjornbaustad.no",
+                        Name = "Budgenix"
+                    },
+                    Subject = $"Your {tier} access has ended",
+                    Html = $@"
+                <table style='width:100%; max-width:600px; margin:auto; font-family:Arial, sans-serif; border-collapse:collapse; background-color:#FDFBF7; border:1px solid #E8DFD2;'>
+                    <tr>
+                        <td style='background-color:#4C7C59; padding:20px; text-align:center; color:#FFFFFF;'>
+                            <h1 style='margin:0; font-size:24px;'>Budgenix</h1>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style='padding:30px; background-color:#F5F1EA;'>
+                            <p style='font-size:16px; color:#2A2927; margin:0 0 16px;'>Hi {firstName},</p>
+                            {messageBody}
+                            <p style='font-size:14px; color:#6b7280; margin:0;'>
+                                You can continue using Budgenix with the Free plan. If you'd like to upgrade again, head over to your account settings.
+                            </p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style='background-color:#E8DFD2; color:#6b7280; padding:15px; text-align:center; font-size:12px;'>
+                            © {DateTime.UtcNow.Year} Budgenix. All rights reserved.
+                        </td>
+                    </tr>
+                </table>"
+                },
+                Recipients = new List<SparkPost.Recipient>
+        {
+            new SparkPost.Recipient
+            {
+                Address = new SparkPost.Address
+                {
+                    Email = toEmail
+                }
+            }
+        }
+            };
+
+            var response = await client.Transmissions.Send(transmission);
+            if (response.StatusCode != HttpStatusCode.OK &&
+                response.StatusCode != HttpStatusCode.Accepted)
+            {
+                throw new Exception("Failed to send subscription revocation email.");
+            }
+        }
+
+
     }
 
 }

--- a/backend/Budgenix.API/Services/Email/IEmailService.cs
+++ b/backend/Budgenix.API/Services/Email/IEmailService.cs
@@ -1,0 +1,12 @@
+﻿using Budgenix.Models.Users;
+
+namespace Budgenix.Services.Email
+{
+    public interface IEmailService
+    {
+        Task SendEmailConfirmationAsync(string toEmail, string confirmationLink);
+        Task SendSubscriptionGrantedEmailAsync(string toEmail, string firstName, SubscriptionTypeEnum tier, DateTime endDate);
+        Task SendSubscriptionRevokedEmailAsync(string toEmail, string firstName, SubscriptionTypeEnum tier, DateTime endDate, string? customMessage = null);
+    }
+}
+

--- a/backend/Budgenix.API/Services/User/IUserService.cs
+++ b/backend/Budgenix.API/Services/User/IUserService.cs
@@ -12,8 +12,10 @@ namespace Budgenix.Services.User
         Task UpdateUserAsync(UpdateUserDto dto);
         Task<string> GetCurrencyAsync();
         Task UpdateCurrencyAsync(string currency);
-
         Task ChangePasswordAsync(UpdatePasswordDto dto);
+        Task<SubscriptionTypeEnum> GetEffectiveSubscriptionTierAsync();
+        Task<SubscriptionTypeEnum> GetEffectiveSubscriptionTierAsync(string userId);
+
 
     }
 }

--- a/backend/Budgenix.API/Services/User/UserService.cs
+++ b/backend/Budgenix.API/Services/User/UserService.cs
@@ -1,7 +1,9 @@
-﻿using Budgenix.Dtos.Users;
+﻿using Budgenix.Data;
+using Budgenix.Dtos.Users;
 using Budgenix.Models.Shared;
 using Budgenix.Models.Users;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Localization;
 using System.Security.Claims;
 
@@ -12,13 +14,19 @@ namespace Budgenix.Services.User
         private readonly IHttpContextAccessor _contextAccessor;
         private readonly IStringLocalizer<SharedResource> _localizer;
         private readonly UserManager<ApplicationUser> _userManager;
+        private readonly BudgenixDbContext _context;
 
-        public UserService(IHttpContextAccessor contextAccessor, IStringLocalizer<SharedResource> localizer, UserManager<ApplicationUser> userManager)
+        public UserService(IHttpContextAccessor contextAccessor, IStringLocalizer<SharedResource> localizer, UserManager<ApplicationUser> userManager, BudgenixDbContext context)
         {
             _contextAccessor = contextAccessor;
             _localizer = localizer;
             _userManager = userManager;
+            _context = context;
         }
+
+        // -------------------------
+        // Context + Claims Access
+        // -------------------------
 
         public string GetUserId()
         {
@@ -38,6 +46,10 @@ namespace Budgenix.Services.User
             return await _userManager.GetUserAsync(_contextAccessor.HttpContext?.User);
         }
 
+        // -------------------------
+        // User Info / Profile
+        // -------------------------
+
         public async Task<UserDto?> GetUserDetailsAsync()
         {
             var user = await GetCurrentUserAsync();
@@ -45,6 +57,15 @@ namespace Budgenix.Services.User
 
             var roles = await _userManager.GetRolesAsync(user);
             var isAdmin = roles.Contains("Admin");
+
+            var now = DateTime.UtcNow;
+            var activeOverride = await _context.ManualSubscriptionOverrides
+                .Where(o => o.UserId == user.Id && o.StartDate <= now && o.EndDate > now)
+                .OrderByDescending(o => o.EndDate)
+                .FirstOrDefaultAsync();
+
+            var effectiveTier = activeOverride?.Tier ?? user.SubscriptionTier;
+
 
             return new UserDto
             {
@@ -59,7 +80,8 @@ namespace Budgenix.Services.User
                 StateOrProvince = user.StateOrProvince,
                 ZipOrPostalCode = user.ZipOrPostalCode,
                 Country = user.Country,
-                SubscriptionTier = user.SubscriptionTier,
+                SubscriptionTier = effectiveTier,
+                OverrideSubscriptionEndDate = activeOverride?.EndDate,
                 SubscriptionIsActive = user.SubscriptionIsActive,
                 SubscriptionStartDate = user.SubscriptionStartDate,
                 SubscriptionEndDate = user.SubscriptionEndDate,
@@ -87,6 +109,10 @@ namespace Budgenix.Services.User
             await _userManager.UpdateAsync(user);
         }
 
+        // -------------------------
+        // Password Management
+        // -------------------------
+
         public async Task ChangePasswordAsync(UpdatePasswordDto dto)
         {
             var user = await GetCurrentUserAsync();
@@ -101,6 +127,9 @@ namespace Budgenix.Services.User
             }
         }
 
+        // -------------------------
+        // Currency Preferences
+        // -------------------------
 
         public async Task<string> GetCurrencyAsync()
         {
@@ -115,6 +144,38 @@ namespace Budgenix.Services.User
 
             user.Currency = currency;
             await _userManager.UpdateAsync(user);
+        }
+
+        // -------------------------
+        // Subscription Overrides
+        // -------------------------
+
+        public async Task<SubscriptionTypeEnum> GetEffectiveSubscriptionTierAsync()
+        {
+            var user = await GetCurrentUserAsync();
+            if (user == null) throw new UnauthorizedAccessException();
+
+            var now = DateTime.UtcNow;
+
+            var activeOverride = await _context.ManualSubscriptionOverrides
+                .Where(o => o.UserId == user.Id && o.StartDate <= now && o.EndDate > now)
+                .OrderByDescending(o => o.EndDate)
+                .FirstOrDefaultAsync();
+
+            return activeOverride?.Tier ?? user.SubscriptionTier;
+        }
+
+        public async Task<SubscriptionTypeEnum> GetEffectiveSubscriptionTierAsync(string userId)
+        {
+            var now = DateTime.UtcNow;
+
+            var activeOverride = await _context.ManualSubscriptionOverrides
+                .Where(o => o.UserId == userId && o.StartDate <= now && o.EndDate > now)
+                .OrderByDescending(o => o.EndDate)
+                .FirstOrDefaultAsync();
+
+            var user = await _userManager.FindByIdAsync(userId);
+            return activeOverride?.Tier ?? user?.SubscriptionTier ?? SubscriptionTypeEnum.Free;
         }
     }
 }

--- a/frontend/src/components/icons/AppIcons.ts
+++ b/frontend/src/components/icons/AppIcons.ts
@@ -48,6 +48,8 @@ import {
   Target,
   Layers,
   CheckCircle2,
+  Check,
+  X,
 
   // Organization / Tags
   Tag,
@@ -143,6 +145,8 @@ export const AppIcons = {
   categories: Layers,
   complete: CheckCircle2,
   landmark: Landmark,
+  check: Check,
+  x: X,
 
   // Organization
   tag: Tag,

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -580,7 +580,19 @@
             "noLogs": "No logs found.",
             "entity": "Entity",
             "id": "ID",
-            "error": "Error"        
+            "error": "Error",
+            "grantOverride": "Grant Subscription Override",
+            "activeOverride": "Active Override Until",
+            "sendEmail":"Send Email?",
+            "messagePlaceholder": "Optional message to include in email",
+            "grant": "Grant Access",
+            "revoke": "Revoke Access",
+            "overridden": "overridden",
+            "overrideGranted": "Override granted successfully.",
+            "overrideError": "Failed to grant override.",
+            "confirmRevoke": "Are you sure you want to revoke the active override?",
+            "overrideRevoked": "Subscription override revoked.",
+            "revokedByAdmin": "Revoked manually by admin"
         }
     },
     "categories": {

--- a/frontend/src/modules/admin/AdminPage.tsx
+++ b/frontend/src/modules/admin/AdminPage.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
-import { useAdminUsers } from './hooks/useAdminUsers';
+import { useAdminUsers } from './hooks/useAdminQuery';
 import { AdminUserDto, AdminUserDetailsDto } from '@/modules/admin/types/admin';
 import { AuditLogDto } from '@/modules/admin/types/auditLogDto';
 import UserDetailsModal from './components/UserDetailsModal';
-import { getAdminUserDetails, getAuditLogsForUser } from './services/adminService';
+import { fetchUserDetails, fetchAuditLogsForUser } from './services/adminService';
+
 import { formatDistanceToNow } from 'date-fns';
 import { useTranslation } from 'react-i18next';
 
@@ -11,7 +12,6 @@ const AdminPage = () => {
   const { t } = useTranslation();
   const { data: users, isLoading, isError } = useAdminUsers();
 
-  const [selectedUser, setSelectedUser] = useState<AdminUserDto | null>(null);
   const [selectedUserDetails, setSelectedUserDetails] = useState<AdminUserDetailsDto | null>(null);
   const [auditLogs, setAuditLogs] = useState<AuditLogDto[]>([]);
   const [loadingDetails, setLoadingDetails] = useState(false);
@@ -21,8 +21,8 @@ const AdminPage = () => {
     setLoadingDetails(true);
     try {
       const [details, logs] = await Promise.all([
-        getAdminUserDetails(userId),
-        getAuditLogsForUser(userId),
+        fetchUserDetails(userId),
+        fetchAuditLogsForUser(userId),
       ]);
       setSelectedUserDetails(details);
       setAuditLogs(logs);
@@ -31,6 +31,11 @@ const AdminPage = () => {
     } finally {
       setLoadingDetails(false);
     }
+  };
+
+  const closeModal = () => {
+    setSelectedUserDetails(null);
+    setAuditLogs([]);
   };
 
   const filteredUsers = users?.filter((user) =>
@@ -56,31 +61,22 @@ const AdminPage = () => {
         />
       </div>
 
-      <div className="w-full overflow-x-auto"> 
+      <div className="w-full overflow-x-auto">
         <table className="min-w-full table-auto border border-base-300">
           <thead>
             <tr className="bg-base-200">
               <th className="text-left p-2">{t('admin.panel.columns.email')}</th>
               <th className="text-left p-2">{t('admin.panel.columns.role')}</th>
-              <th className="text-left p-2 hidden md:table-cell">
-                {t('admin.panel.columns.tier')}
-              </th>
-              <th className="text-left p-2 hidden md:table-cell">
-                {t('admin.panel.columns.signup')}
-              </th>
+              <th className="text-left p-2 hidden md:table-cell">{t('admin.panel.columns.tier')}</th>
+              <th className="text-left p-2 hidden md:table-cell">{t('admin.panel.columns.signup')}</th>
               <th className="text-left p-2">{t('admin.panel.columns.lastActive')}</th>
-              {/* <th className="text-left p-2">{t('shared.actions')}</th> */}
-
             </tr>
           </thead>
           <tbody>
             {filteredUsers?.map((user: AdminUserDto) => (
               <tr
                 key={user.id}
-                onClick={() => {
-                  setSelectedUser(user);
-                  openUserModal(user.id);
-                }}
+                onClick={() => openUserModal(user.id)}
                 className="border-t border-base-300 hover:bg-base-200 cursor-pointer"
               >
                 <td className="p-2">{user.email.split('@')[0]}</td>
@@ -98,21 +94,18 @@ const AdminPage = () => {
                     ? formatDistanceToNow(new Date(user.lastLogin), { addSuffix: true })
                     : '—'}
                 </td>
-                {/* <td className="p-2">
-                  <button className="btn btn-xs btn-error">{t('buttons.delete')}</button>
-                </td> */}
               </tr>
             ))}
           </tbody>
         </table>
       </div>
 
-      {selectedUser && (
+      {selectedUserDetails && (
         <UserDetailsModal
           user={selectedUserDetails}
           auditLogs={auditLogs}
           loading={loadingDetails}
-          onClose={() => setSelectedUser(null)}
+          onClose={closeModal}
         />
       )}
     </div>

--- a/frontend/src/modules/admin/components/UserDetailsModal.tsx
+++ b/frontend/src/modules/admin/components/UserDetailsModal.tsx
@@ -1,9 +1,11 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { AuditLogDto } from '@/modules/admin/types/auditLogDto';
 import { AdminUserDetailsDto } from '@/modules/admin/types/admin';
 import { formatDistanceToNow } from 'date-fns';
 import { AppIcons } from '@/components/icons/AppIcons';
 import { useTranslation } from 'react-i18next';
+import { useGrantManualSubscriptionOverride, useRevokeManualSubscriptionOverride } from '../services/adminService';
+import { toast } from 'react-hot-toast';
 
 interface Props {
   user: AdminUserDetailsDto | null;
@@ -14,6 +16,48 @@ interface Props {
 
 const UserDetailsModal = ({ user, auditLogs, loading, onClose }: Props) => {
   const { t } = useTranslation();
+  const [selectedTier, setSelectedTier] = useState<'Hobby' | 'Pro'>('Pro');
+  const [endDate, setEndDate] = useState('');
+  const [granting, setGranting] = useState(false);
+  const [customMessage, setCustomMessage] = useState('');
+  const [sendEmail, setSendEmail] = useState(true);
+
+  const { mutateAsync: grantManualSubscription } = useGrantManualSubscriptionOverride();
+  const { mutateAsync: revokeManualSubscription } = useRevokeManualSubscriptionOverride();
+  const handleGrantOverride = async () => {
+    if (!user || !endDate) return;
+
+    try {
+      setGranting(true);
+      await grantManualSubscription({
+        userId: user.id,
+        tier: selectedTier,
+        startDate: new Date().toISOString(),
+        endDate: new Date(endDate).toISOString(),
+        customMessage: customMessage.trim() || undefined,
+        sendEmail,
+      });
+
+      toast.success(t('admin.userDetails.overrideGranted'));
+    } catch (err) {
+      console.error('Error granting subscription override', err);
+      toast.error(t('admin.userDetails.overrideError'));
+    } finally {
+      setGranting(false);
+    }
+  };
+
+  useEffect(() => {
+    console.log('[UserDetailsModal] Loaded user:', user);
+    console.log('[UserDetailsModal] manualOverrides:', user?.manualOverrides);
+
+    const sorted = [...(user?.manualOverrides ?? [])]
+      .sort((a, b) => new Date(b.endDate).getTime() - new Date(a.endDate).getTime());
+
+    console.log('[UserDetailsModal] Sorted overrides:', sorted);
+    console.log('[UserDetailsModal] Latest override:', sorted[0]);
+  }, [user]);
+
 
   useEffect(() => {
     const handleEsc = (e: KeyboardEvent) => {
@@ -35,6 +79,9 @@ const UserDetailsModal = ({ user, auditLogs, loading, onClose }: Props) => {
       </div>
     );
   }
+
+  const latestOverride = [...(user.manualOverrides ?? [])]
+    .sort((a, b) => new Date(b.endDate).getTime() - new Date(a.endDate).getTime())[0];
 
   const InfoItem = ({
     icon: Icon,
@@ -85,8 +132,13 @@ const UserDetailsModal = ({ user, auditLogs, loading, onClose }: Props) => {
               <InfoItem
                 icon={AppIcons.secure}
                 label={t('admin.userDetails.emailConfirmed')}
-                value={user.emailConfirmed ? '✔️' : '❌'}
-                color={user.emailConfirmed ? 'text-success' : 'text-error'}
+                value={
+                  user.emailConfirmed ? (
+                    <AppIcons.check className="w-4 h-4 text-success" />
+                  ) : (
+                    <AppIcons.x className="w-4 h-4 text-error" />
+                  )
+                }
               />
               <InfoItem icon={AppIcons.secure} label={t('admin.userDetails.role')} value={user.role} />
               <InfoItem icon={AppIcons.globe} label={t('shared.country')} value={user.country ?? '—'} />
@@ -95,18 +147,120 @@ const UserDetailsModal = ({ user, auditLogs, loading, onClose }: Props) => {
             </Section>
 
             <Section title={t('admin.userDetails.subscription')}>
-              <InfoItem icon={AppIcons.wallet} label={t('settings.profile.fields.tier')} value={user.subscriptionTier} />
+              <InfoItem
+                icon={AppIcons.wallet}
+                label={t('settings.profile.fields.tier')}
+                value={
+                  latestOverride ? (
+                    <span>
+                      <span className="font-semibold">{latestOverride.tier}</span>{' '}
+                      <span className="text-xs text-base-content/70">
+                        ({t('admin.userDetails.overridden')} – {new Date(latestOverride.endDate).toLocaleDateString()})
+                      </span>
+                    </span>
+                  ) : (
+                    user.subscriptionTier
+                  )
+                }
+              />
               <InfoItem
                 icon={AppIcons.lock}
                 label={t('admin.userDetails.active')}
-                value={user.subscriptionIsActive ? '✔️' : '❌'}
-                color={user.subscriptionIsActive ? 'text-success' : 'text-error'}
+                value={user.subscriptionIsActive ? (
+                    <AppIcons.check className="w-4 h-4 text-success" />
+                  ) : (
+                    <AppIcons.x className="w-4 h-4 text-error" />
+                  )
+                }                
               />
               <InfoItem icon={AppIcons.calendar} label={t('settings.profile.fields.billingCycle')} value={user.billingCycle} />
               <InfoItem icon={AppIcons.arrowUp} label={t('admin.userDetails.start')} value={user.subscriptionStartDate ? new Date(user.subscriptionStartDate).toLocaleDateString() : '—'} />
               <InfoItem icon={AppIcons.arrowDown} label={t('admin.userDetails.end')} value={user.subscriptionEndDate ? new Date(user.subscriptionEndDate).toLocaleDateString() : '—'} />
               <InfoItem icon={AppIcons.assets} label={t('settings.app.currency')} value={user.preferredCurrency ?? '—'} />
               <InfoItem icon={AppIcons.tag} label={t('admin.userDetails.referral')} value={user.referralCode ?? '—'} />
+            </Section>
+
+            <Section title={t('admin.userDetails.grantOverride')}>
+              {latestOverride && (
+                <div className="flex items-center gap-2 text-info text-sm mb-2">
+                  <AppIcons.warning className="w-4 h-4" />
+                  <span className="font-medium">
+                    {t('admin.userDetails.activeOverride')}: {new Date(latestOverride.endDate).toLocaleDateString()}
+                  </span>
+                </div>
+              )}
+
+              <div className="flex flex-col gap-3 mt-2">
+                <div className="flex flex-col md:flex-row gap-3">
+                  <select
+                    className="select select-bordered w-full md:w-40"
+                    value={selectedTier}
+                    onChange={(e) => setSelectedTier(e.target.value as 'Hobby' | 'Pro')}
+                  >
+                    <option value="Hobby">Hobby</option>
+                    <option value="Pro">Pro</option>
+                  </select>
+
+                  <input
+                    type="date"
+                    className="input input-bordered w-full md:w-48"
+                    value={endDate}
+                    onChange={(e) => setEndDate(e.target.value)}
+                  />
+                </div>
+
+                <textarea
+                  className="textarea textarea-bordered w-full"
+                  rows={2}
+                  placeholder={t('admin.userDetails.messagePlaceholder')}
+                  value={customMessage}
+                  onChange={(e) => setCustomMessage(e.target.value)}
+                />
+
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    className="checkbox checkbox-sm"
+                    checked={sendEmail}
+                    onChange={(e) => setSendEmail(e.target.checked)}
+                  />
+                  <span>{t('admin.userDetails.sendEmail')}</span>
+                </label>
+
+                <div className="flex gap-2 mt-2">
+                  <button
+                    className="btn btn-sm btn-success"
+                    disabled={granting}
+                    onClick={handleGrantOverride}
+                  >
+                    {granting ? t('buttons.saving') : t('admin.userDetails.grant')}
+                  </button>
+
+                  {latestOverride && (
+                    <button
+                      className="btn btn-sm btn-outline btn-error"
+                      onClick={async () => {
+                        const confirmed = confirm(t('admin.userDetails.confirmRevoke'));
+                        if (!confirmed || !user) return;
+
+                        try {
+                          await revokeManualSubscription({
+                            overrideId: latestOverride.id,
+                            userId: user.id,
+                            customMessage: t('admin.userDetails.revokedByAdmin'),
+                          });
+                          toast.success(t('admin.userDetails.overrideRevoked'));
+                        } catch (err) {
+                          console.error('Error revoking override', err);
+                          toast.error(t('admin.userDetails.overrideError'));
+                        }
+                      }}
+                    >
+                      {t('admin.userDetails.revoke')}
+                    </button>
+                  )}
+                </div>
+              </div>
             </Section>
 
             <Section title={t('admin.userDetails.usage')}>

--- a/frontend/src/modules/admin/context/adminContext.tsx
+++ b/frontend/src/modules/admin/context/adminContext.tsx
@@ -1,0 +1,144 @@
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useCallback,
+  useState,
+  ReactNode,
+} from 'react';
+
+import {
+  useAdminUsers,
+  useAdminUserDetails,
+  useAuditLogsForUser,
+} from '../hooks/useAdminQuery';
+
+import { 
+    useDeleteUser, 
+    useDeleteUserItem, 
+    useGrantManualSubscriptionOverride, 
+    useRevokeManualSubscriptionOverride
+} from '../services/adminService';
+
+import {
+  AdminUserDto,
+  AdminUserDetailsDto,
+  GrantSubscriptionOverrideDto,
+} from '@/modules/admin/types/admin';
+import { AuditLogDto } from '@/modules/admin/types/auditLogDto';
+
+
+type AdminContextType = {
+  adminUsers: AdminUserDto[];
+  selectedUserDetails: AdminUserDetailsDto | null;
+  auditLogs: AuditLogDto[];
+  loading: boolean;
+  selectUser: (userId: string) => Promise<void>;
+  closeUserModal: () => void;
+  grantOverride: (dto: GrantSubscriptionOverrideDto) => Promise<void>;
+  deleteUser: (userId: string) => Promise<void>;
+  deleteUserItem: (userId: string, itemType: string, itemId: string) => Promise<void>;
+  revokeOverride: (overrideId: string, userId: string, customMessage?: string) => Promise<void>;
+
+};
+
+const AdminContext = createContext<AdminContextType | undefined>(undefined);
+
+export const AdminProvider = ({ children }: { children: ReactNode }) => {
+  const { data: users = [], isLoading: isUsersLoading } = useAdminUsers();    
+  const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
+
+  const {
+    data: userDetails,
+    isLoading: isDetailsLoading,
+  } = useAdminUserDetails(selectedUserId ?? '');
+
+  const {
+    data: logs = [],
+    isLoading: isLogsLoading,
+  } = useAuditLogsForUser(selectedUserId ?? '');
+
+  const grantMutation = useGrantManualSubscriptionOverride();
+  const deleteUserMutation = useDeleteUser();
+  const deleteUserItemMutation = useDeleteUserItem();
+  const revokeMutation = useRevokeManualSubscriptionOverride();
+  
+  const selectUser = useCallback(async (id: string) => {
+    setSelectedUserId(id);
+  }, []);
+
+  const closeUserModal = useCallback(() => {
+    setSelectedUserId(null);
+  }, []);
+
+  const grantOverride = useCallback(
+    async (dto: GrantSubscriptionOverrideDto) => {
+      await grantMutation.mutateAsync(dto);
+    },
+    [grantMutation]
+  );
+
+  const revokeOverride = useCallback(
+    async (overrideId: string, userId: string, customMessage?: string) => {
+        await revokeMutation.mutateAsync({ overrideId, userId, customMessage });
+    },
+    [revokeMutation]
+    );
+
+  const deleteUser = useCallback(
+    async (userId: string) => {
+      await deleteUserMutation.mutateAsync(userId);
+    },
+    [deleteUserMutation]
+  );
+
+  const deleteUserItem = useCallback(
+    async (userId: string, itemType: string, itemId: string) => {
+      await deleteUserItemMutation.mutateAsync({ userId, itemType, itemId });
+    },
+    [deleteUserItemMutation]
+  );
+
+  const value = useMemo<AdminContextType>(
+    () => ({
+      adminUsers: users,
+      selectedUserDetails: userDetails ?? null,
+      auditLogs: logs,
+      loading: isUsersLoading || isDetailsLoading || isLogsLoading,
+      selectUser,
+      closeUserModal,
+      grantOverride,
+      revokeOverride,
+      deleteUser,
+      deleteUserItem,
+    }),
+    [
+      users,
+      userDetails,
+      logs,
+      isUsersLoading,
+      isDetailsLoading,
+      isLogsLoading,
+      selectUser,
+      closeUserModal,
+      grantOverride,
+      revokeOverride,
+      deleteUser,
+      deleteUserItem,
+    ]
+  );
+
+  return (
+    <AdminContext.Provider value={value}>
+      {children}
+    </AdminContext.Provider>
+  );
+};
+
+export function useAdminContext() {
+  const context = useContext(AdminContext);
+  if (!context) {
+    throw new Error('useAdminContext must be used within an AdminProvider');
+  }
+  return context;
+}

--- a/frontend/src/modules/admin/hooks/useAdminQuery.ts
+++ b/frontend/src/modules/admin/hooks/useAdminQuery.ts
@@ -1,0 +1,43 @@
+// hooks/useAdminQuery.ts
+
+import { useQuery } from '@tanstack/react-query';
+import {
+  fetchAdminUsers,
+  fetchUserDetails,
+  fetchAuditLogsForUser,
+  fetchManualOverrides,
+} from '../services/adminService';
+import {
+  AdminUserDto,
+  AdminUserDetailsDto,
+  ManualSubscriptionOverrideDto,
+} from '@/modules/admin/types/admin';
+import { AuditLogDto } from '@/modules/admin/types/auditLogDto';
+
+export const useAdminUsers = () =>
+  useQuery<AdminUserDto[]>({
+    queryKey: ['admin', 'users'],
+    queryFn: fetchAdminUsers,
+    staleTime: 5 * 60 * 1000,
+  });
+
+export const useAdminUserDetails = (userId: string) =>
+  useQuery<AdminUserDetailsDto>({
+    queryKey: ['admin', 'user', userId],
+    queryFn: () => fetchUserDetails(userId),
+    enabled: !!userId,
+  });
+
+export const useAuditLogsForUser = (userId: string) =>
+  useQuery<AuditLogDto[]>({
+    queryKey: ['admin', 'logs', userId],
+    queryFn: () => fetchAuditLogsForUser(userId),
+    enabled: !!userId,
+  });
+
+export const useManualOverrides = (userId: string) =>
+  useQuery<ManualSubscriptionOverrideDto[]>({
+    queryKey: ['admin', 'overrides', userId],
+    queryFn: () => fetchManualOverrides(userId),
+    enabled: !!userId,
+  });

--- a/frontend/src/modules/admin/hooks/useAdminUsers.ts
+++ b/frontend/src/modules/admin/hooks/useAdminUsers.ts
@@ -1,9 +1,0 @@
-import { useQuery } from '@tanstack/react-query';
-import { getAdminUsers } from '../services/adminService';
-import { AdminUserDto } from '@/modules/admin/types/admin';
-
-export const useAdminUsers = () =>
-  useQuery<AdminUserDto[]>({
-    queryKey: ['admin', 'users'],
-    queryFn: getAdminUsers,
-  });

--- a/frontend/src/modules/admin/services/adminService.ts
+++ b/frontend/src/modules/admin/services/adminService.ts
@@ -1,63 +1,134 @@
+// services/adminService.ts
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiFetch } from '@/utils/api';
 import {
   AdminUserDto,
   AdminUserDetailsDto,
   AdminDeleteResultDto,
+  ManualSubscriptionOverrideDto,
+  GrantSubscriptionOverrideDto,
 } from '@/modules/admin/types/admin';
+import { AuditLogDto } from '@/modules/admin/types/auditLogDto';
 
-import { AuditLogDto } from '../types/auditLogDto';
+// === API Base URL ===
+const API_URL = '/api/admin';
 
-/**
- * Fetch all users for the admin panel
- */
-export const getAdminUsers = async (): Promise<AdminUserDto[]> => {
-  const result = await apiFetch<AdminUserDto[]>('/api/admin/users');
+// === Query Keys ===
+export const AdminQueryKeys = {
+  users: ['admin', 'users'] as const,
+  user: (id: string) => ['admin', 'user', id] as const,
+  auditLogs: (id: string) => ['admin', 'logs', id] as const,
+  manualOverrides: (id: string) => ['admin', 'overrides', id] as const,
+};
+
+// === Pure API Fetch Functions ===
+
+export async function fetchAdminUsers(): Promise<AdminUserDto[]> {
+  const result = await apiFetch<AdminUserDto[]>(`${API_URL}/users`);
   if (!result) throw new Error('Failed to fetch admin users');
   return result;
-};
+}
 
-/**
- * Get details of a specific user
- */
-export const getAdminUserDetails = async (userId: string): Promise<AdminUserDetailsDto> => {
-  const result = await apiFetch<AdminUserDetailsDto>(`/api/admin/user/${userId}`);
+export async function fetchUserDetails(userId: string): Promise<AdminUserDetailsDto> {
+  const result = await apiFetch<AdminUserDetailsDto>(`${API_URL}/user/${userId}`);
   if (!result) throw new Error('Failed to fetch user details');
   return result;
-};
+}
 
-
-export const getAuditLogsForUser = async (userId: string): Promise<AuditLogDto[]> => {
-  const result = await apiFetch<AuditLogDto[]>(`/api/admin/user/${userId}/logs`);
+export async function fetchAuditLogsForUser(userId: string): Promise<AuditLogDto[]> {
+  const result = await apiFetch<AuditLogDto[]>(`${API_URL}/user/${userId}/logs`);
   if (!result) throw new Error('Failed to fetch audit logs');
   return result;
-};
+}
 
-
-/**
- * Delete a user and all their data
- */
-export const deleteUser = async (userId: string): Promise<AdminDeleteResultDto> => {
-  const result = await apiFetch<AdminDeleteResultDto>(`/api/admin/user/${userId}`, {
-    method: 'DELETE',
-  });
-  if (!result) throw new Error('No response from deleteUser');
+export async function fetchManualOverrides(userId: string): Promise<ManualSubscriptionOverrideDto[]> {
+  const result = await apiFetch<ManualSubscriptionOverrideDto[]>(`${API_URL}/user/${userId}/overrides`);
+  if (!result) throw new Error('Failed to fetch manual subscription overrides');
   return result;
-};
+}
 
-/**
- * Delete a specific item for a user (e.g. an expense)
- */
-export const deleteUserItem = async (
-  userId: string,
-  itemType: 'expense' | 'income' | 'budget' | 'goal',
-  itemId: string
-): Promise<void> => {
-  const result = await apiFetch<void>(`/api/admin/user/${userId}/${itemType}/${itemId}`, {
+export async function deleteUser(userId: string): Promise<AdminDeleteResultDto> {
+  const result = await apiFetch<AdminDeleteResultDto>(`${API_URL}/user/${userId}`, {
     method: 'DELETE',
   });
+  if (!result) throw new Error('Failed to delete user');
+  return result;
+}
 
-  if (result !== null) {
-    // Optionally warn if something was returned when it shouldn't be
-    console.warn('Expected no content for deleteUserItem, but got:', result);
-  }
-};
+export async function deleteUserItem(userId: string, itemType: string, itemId: string): Promise<void> {
+  await apiFetch(`${API_URL}/user/${userId}/${itemType}/${itemId}`, {
+    method: 'DELETE',
+  });
+}
+
+export async function grantManualSubscriptionOverride(data: GrantSubscriptionOverrideDto): Promise<void> {
+  await apiFetch(`${API_URL}/user/${data.userId}/grant-subscription`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+}
+
+export async function revokeManualSubscriptionOverride(
+  overrideId: string,
+  userId: string,
+  customMessage?: string
+): Promise<void> {
+  await apiFetch(`/api/admin/user/${userId}/revoke-override/${overrideId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ customMessage }),
+  });
+}
+
+
+// === Mutation Hooks ===
+
+export function useGrantManualSubscriptionOverride() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: grantManualSubscriptionOverride,
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: AdminQueryKeys.manualOverrides(variables.userId) });
+      queryClient.invalidateQueries({ queryKey: AdminQueryKeys.user(variables.userId) });
+    },
+  });
+}
+
+export function useDeleteUser() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteUser,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: AdminQueryKeys.users });
+    },
+  });
+}
+
+export function useDeleteUserItem() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (params: { userId: string; itemType: string; itemId: string }) =>
+      deleteUserItem(params.userId, params.itemType, params.itemId),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: AdminQueryKeys.user(variables.userId) });
+    },
+  });
+}
+
+export function useRevokeManualSubscriptionOverride() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { overrideId: string; userId: string; customMessage?: string }) =>
+      revokeManualSubscriptionOverride(data.overrideId, data.userId, data.customMessage),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: AdminQueryKeys.manualOverrides(variables.userId) });
+      queryClient.invalidateQueries({ queryKey: AdminQueryKeys.user(variables.userId) });
+    },
+  });
+}
+

--- a/frontend/src/modules/admin/types/admin.ts
+++ b/frontend/src/modules/admin/types/admin.ts
@@ -1,4 +1,24 @@
-import { AuditLogDto } from "./auditLogDto";
+import { AuditLogDto } from './auditLogDto';
+
+// Manual Subscription Override DTO
+export interface ManualSubscriptionOverrideDto {
+  id: string;
+  userId: string;
+  tier: string;
+  startDate: string;
+  endDate: string;
+  grantedBy: string;
+}
+
+// Used for POSTing a new override
+export interface GrantSubscriptionOverrideDto {
+  userId: string;
+  tier: string;
+  startDate: string;
+  endDate: string;
+  sendEmail?: boolean;
+  customMessage?: string;   
+}
 
 export interface AdminUserDto {
   id: string;
@@ -29,6 +49,7 @@ export interface AdminUserDetailsDto extends AdminUserDto {
     goals: number;
   };
   recentLogs: AuditLogDto[];
+  manualOverrides?: ManualSubscriptionOverrideDto[];
 }
 
 export interface AdminDeleteResultDto {


### PR DESCRIPTION
# ✨ Admin Manual Subscription Override System

This PR introduces full support for manually managing subscription overrides from the AdminPanel. Admins can now grant or revoke manual access to paid tiers for individual users, with optional email notifications.

---

## ✅ Features Implemented

### 🔧 Backend
- Added `ManualSubscriptionOverride` entity support in DTOs and queries
- Extended `AdminUserDetailsDto` to include `manualOverrides`
- Implemented `GrantManualSubscriptionOverride` and `RevokeManualSubscriptionOverride` endpoints
- Added support for sending optional email notifications when granting or revoking access
- Hooked into audit logging with override metadata

### 🧑‍💻 Frontend
- Updated `UserDetailsModal` with new **Grant Override** section:
  - Select tier (`Hobby`, `Pro`)
  - Choose end date
  - Write optional custom message
  - Toggle "Send Email"
  - Submit with **Grant Access** or **Revoke Access**
- Displays active override until date if available
- Improved styling and clarity:
  - AppIcons instead of emoji
  - Better button consistency
  - Adjusted visibility of override warning

---

## 📬 Email Support
- Email is sent when `Send Email` is toggled (both grant and revoke)
- Message body includes the custom message entered in the textarea
- Logs include whether email was sent